### PR TITLE
For user/edit, hiding some fields (D8-1343)

### DIFF
--- a/modules/user_profiles/user_profiles.module
+++ b/modules/user_profiles/user_profiles.module
@@ -27,19 +27,35 @@ function user_profiles_menu_local_tasks_alter(&$data, $route_name) {
  * be able to set or change their username.
  */
 function user_profiles_form_alter(&$form, &$form_state, $form_id) {
+  // Get current domain
+  $token = \Drupal::token();
+  $domainName = t("[domain:name]");
+  $current_domain_name = Html::getClass($token->replace($domainName));
+  $is_asp = $current_domain_name == 'access-support';
+
   switch ($form_id) {
     case 'change_pwd_form':
-      // Get current domain
-      $domain = \Drupal::config('domain.settings');
-      $token = \Drupal::token();
-      $domainName = t("[domain:name]");
-      $current_domain_name = Html::getClass($token->replace($domainName));
-      if ( $current_domain_name == 'access-support' ) {
+      if ($is_asp ) {
         $response = new RedirectResponse('/user');
         $response->send();
       }
       break;
+
     case 'user_form':
+      if ($is_asp) {
+
+        $user_roles = \Drupal::currentUser()->getRoles();
+        $is_admin = in_array('administrator', $user_roles);
+      
+        if (!$is_admin) {
+          $form['field_user_first_name']['#access'] = FALSE;
+          $form['field_user_last_name']['#access'] = FALSE;
+          $form['field_institution']['#access'] = FALSE;
+          $form['field_citizenships']['#access'] = FALSE;
+          $form['account']['mail']['#access'] = FALSE;
+        }
+      }
+
       $form['account']['name']['#access'] = FALSE;
       // no break - fallthrough!
 

--- a/modules/user_profiles/user_profiles.module
+++ b/modules/user_profiles/user_profiles.module
@@ -43,11 +43,10 @@ function user_profiles_form_alter(&$form, &$form_state, $form_id) {
 
     case 'user_form':
       if ($is_asp) {
-
         $user_roles = \Drupal::currentUser()->getRoles();
         $is_admin = in_array('administrator', $user_roles);
-      
         if (!$is_admin) {
+          $form['role_change']['#access'] = FALSE;
           $form['field_user_first_name']['#access'] = FALSE;
           $form['field_user_last_name']['#access'] = FALSE;
           $form['field_institution']['#access'] = FALSE;

--- a/modules/user_profiles/user_profiles.module
+++ b/modules/user_profiles/user_profiles.module
@@ -46,7 +46,6 @@ function user_profiles_form_alter(&$form, &$form_state, $form_id) {
         $user_roles = \Drupal::currentUser()->getRoles();
         $is_admin = in_array('administrator', $user_roles);
         if (!$is_admin) {
-          $form['role_change']['#access'] = FALSE;
           $form['field_user_first_name']['#access'] = FALSE;
           $form['field_user_last_name']['#access'] = FALSE;
           $form['field_institution']['#access'] = FALSE;


### PR DESCRIPTION
For https://cyberteamportal.atlassian.net/browse/D8-1343:  On the ASP, hide the following fields for the edit_profile form for people who are not admins:   Email, First Name, Last Name, Institution, Citizenships

This may be ready for merge.  When looking at the page as a non-admin, the styling is a bit hodge-podge, though this was the pre-existing styling, no style changes were introduced with this work.

For non-admin users, I did have also have to hide Roles -- and there were questions about why this was appearing. 