### PR TITLE
D8 1432  new outages endpoint

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -270,6 +270,7 @@ function add_ag_taxonomy_term($entity) {
  */
 function ag_taxonomy_lookup($ag_title) {
   // Ok to pass null -- returns null if $ag_title is null.
+  // TODO deprecated
   $lookup = taxonomy_term_load_multiple_by_name($ag_title, 'affinity_groups');
   return $lookup;
 }

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -74,8 +74,7 @@ function access_affinitygroup_entity_presave(EntityInterface $entity) {
 
       // If present, remove this AG from this user's block list.
       removeBlockedAG($taxonomyId, $userDetails);
-    }
-    else {
+    } else {
       // Case 2: Affinity group edit was saved by admin user.
       update_ag_leader_roles($entity);
       add_ag_taxonomy_term($entity);
@@ -121,8 +120,7 @@ function access_affinitygroup_entity_presave(EntityInterface $entity) {
 
         if (!empty($list_id)) {
           $entity->set('field_list_id', $list_id);
-        }
-        else {
+        } else {
           showStatus('Bad Constant Contact list id.');
         }
       }
@@ -152,7 +150,7 @@ function access_affinitygroup_views_pre_render(ViewExecutable $view) {
         if (array_key_exists('target_id', $cider_id)) {
           $node = $node_storage->load($cider_id['target_id']);
           $cider_text .= '<h3>' . $node->get('title')->value . '</h3><p>'
-              . $node->get('body')->value . '</p>';
+            . $node->get('body')->value . '</p>';
         }
       }
 
@@ -228,7 +226,6 @@ function update_removed_ag_leader_roles($entity, $coordinator_ids) {
       $coordinators = $affinity_group->get('field_coordinator')->getValue();
       foreach ($coordinators as $coordinator) {
         $all_other_coordinator_ids[] = $coordinator['target_id'];
-        ;
       }
     }
 
@@ -243,8 +240,7 @@ function update_removed_ag_leader_roles($entity, $coordinator_ids) {
         $user->removeRole('affinity_group_leader');
         $user->save();
         \Drupal::messenger()->addStatus('Removed Affinity Group Leader role for ' . $user->getAccountName());
-      }
-      else {
+      } else {
         \Drupal::messenger()->addStatus('Not removing Affinity Group Leader role for ' . $user->getAccountName()
           . ' because coordinator for another Affinity Group');
       }
@@ -261,8 +257,7 @@ function add_ag_taxonomy_term($entity) {
   $tid = NULL;
   if ($exists) {
     $tid = array_keys(ag_taxonomy_lookup($ag_title))[0];
-  }
-  else {
+  } else {
     $tid = create_ag_taxonomy_term($ag_title);
   }
 
@@ -298,8 +293,7 @@ function subscribeToCCList($taxonomyId, $userDetails) {
   $postJSON = makeListMembershipJSON($taxonomyId, $userDetails);
   if (empty($postJSON)) {
     showStatus("Can't add user to email list; check if user is missing Constant Contact ID.");
-  }
-  else {
+  } else {
     $cca = new ConstantContactApi();
     $ccResponse = $cca->apiCall('/activities/add_list_memberships', $postJSON, 'POST');
   }
@@ -337,9 +331,7 @@ function access_affinitygroup_entity_delete(EntityInterface $entity) {
       }
       // Put this AG on this user's block list if not already there.
       addBlockedAG($taxonomyId, $userDetails);
-
-    }
-    else {
+    } else {
       // Case 2: AG getting deleted.
       $title = $entity->getTitle();
       $cca = new ConstantContactApi();
@@ -392,8 +384,7 @@ function removeBlockedAG($agTaxonomyId, $userDetails) {
   foreach ($userBlockedArray as $userBlock) {
     if ($userBlock['target_id'] !== $agTaxonomyId) {
       $userBlockedTaxIds[] = $userBlock['target_id'];
-    }
-    else {
+    } else {
       $wasBlocked = TRUE;
     }
   }
@@ -439,7 +430,6 @@ function makeListMembershipJSON($flagEntityId, $userDetails) {
   $fieldVal = $ag->get('field_list_id')->getValue();
   if (!empty($fieldVal)) {
     $list_cc_id = $fieldVal[0]['value'];
-    ;
   }
 
   if (empty($list_cc_id)) {
@@ -481,13 +471,11 @@ function access_affinitygroup_user_login(UserInterface $account) {
     $cca_user_id = addUserToConstantContact($current_user->getEmail(), $firstName, $lastName);
     if (empty($cca_user_id)) {
       showStatus("Could not add user to Constant Contact.");
-    }
-    else {
+    } else {
       $user_detail->set('field_constant_contact_id', $cca_user_id);
       $user_detail->save();
     }
-  }
-  else {
+  } else {
     // This else just for debugging in early stages
     // showStatus("Login and NOT attempting add of new constant contact id.");.
   }
@@ -542,10 +530,9 @@ function access_affinitygroup_cron() {
       // $aui->updateUserAllocations();
       // emailDevCronLog(); // this function needs to be fixed.
     }
-  }
-  catch (Exception $e) {
+  } catch (Exception $e) {
     \Drupal::logger('cron_affinitygroup')->notice('exception in cron test: ' . $e->getMessage());
-  }  finally {
+  } finally {
     \Drupal::state()->set('access_affinitygroup.cronrunning', FALSE);
   }
 }
@@ -562,17 +549,15 @@ function shouldRun($function) {
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-t', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
     \Drupal::logger('cron_affinitygroup')->notice("checking $function last "
-                                                . date("Y-m-d H:i:s", $lastRun)
-                                                . " now " . date("Y-m-d H:i:s", $currentTime)
-                                                . "; hours diff $hoursDiff ");
+      . date("Y-m-d H:i:s", $lastRun)
+      . " now " . date("Y-m-d H:i:s", $currentTime)
+      . "; hours diff $hoursDiff ");
 
     // Run if it's been at least 6 hours since the last run.
     if ($hoursDiff >= 6) {
       return TRUE;
     }
-
-  }
-  elseif ($function == 'users') {
+  } elseif ($function == 'users') {
 
     // TEMP TEMP JUST DON'T RUN IMPORT CRON FOR NOW.
     return FALSE;
@@ -590,9 +575,9 @@ function shouldRun($function) {
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-u', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
     \Drupal::logger('cron_affinitygroup')->notice("checking $function last "
-                                                  . date("Y-m-d H:i:s", $lastRun)
-                                                  . " now " . date("Y-m-d H:i:s", $currentTime)
-                                                  . "; hours diff $hoursDiff ", 'd');
+      . date("Y-m-d H:i:s", $lastRun)
+      . " now " . date("Y-m-d H:i:s", $currentTime)
+      . "; hours diff $hoursDiff ", 'd');
 
     // Run if it's been more than 24 hours since the last run.
     if ($hoursDiff > 24) {
@@ -648,8 +633,7 @@ function emailToAffinityGroups($emailText, $emailTitle, $pubDate, $agNames, $new
   // Either use email template for access or community.
   if ($communityTemplate) {
     $emailHtml = ccCommunityNewsHTML($emailText, $emailTitle, $pubDate, $agNames, $newsUrl, $logoUrl);
-  }
-  else {
+  } else {
     $emailHtml = ccAccessNewsHTML($emailText, $emailTitle, $pubDate, $agNames, $newsUrl);
   }
 
@@ -724,8 +708,7 @@ function sendEmailCampaign($campaignId, $campaignActivityId, $ccListIds) {
   }
   if ($sent) {
     showStatus("News item emailed to specified affinity groups.");
-  }
-  else {
+  } else {
     showStatus("Error while trying to email news items to affinity groups.");
   }
 }

--- a/modules/access_outages/access_outages.libraries.yml
+++ b/modules/access_outages/access_outages.libraries.yml
@@ -6,6 +6,6 @@ outages_library:
       css/access_outages.css: {}
   js:
     //cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js: {}
-    js/access_outages.js: {}
+    js/affinity_group_outages.js: {}
   dependencies:
     - core/jquery

--- a/modules/access_outages/access_outages.module
+++ b/modules/access_outages/access_outages.module
@@ -21,14 +21,6 @@ function access_outages_theme() {
  */
 function access_outages_preprocess_views_view(&$vars) {
   $view = &$vars['view'];
-
-  $msg =  __FUNCTION__ . '() - $view->id() = '  . print_r($view->id(), true)
-    . ' -- ' . basename(__FILE__) . ':' . __LINE__;
-  \Drupal::messenger()->addStatus($msg);
-  // error_log('======= $text = [' . $text . '] -- ' . basename(__FILE__) . ':' . __LINE__);
-
-
-
   if ($view->id() == 'affinity_group' &&  $view->current_display == 'group') {
 
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');
@@ -45,9 +37,6 @@ function access_outages_preprocess_views_view(&$vars) {
         }
       }
     }
-    $msg =  __FUNCTION__ . '() - $cider_ids = '  . print_r($cider_ids, true)
-      . ' -- ' . basename(__FILE__) . ':' . __LINE__;
-    \Drupal::messenger()->addStatus($msg);
 
     if (count($cider_resource_ids) > 0) {
       $vars['#attached']['library'][] = 'access_outages/outages_library';

--- a/modules/access_outages/access_outages.module
+++ b/modules/access_outages/access_outages.module
@@ -5,8 +5,7 @@ use Drupal\views\ViewExecutable;
 /**
  * Implements hook_theme().
  */
-function access_outages_theme()
-{
+function access_outages_theme() {
   return [
     'outages_block' => [
       'variables' => [
@@ -20,9 +19,16 @@ function access_outages_theme()
  * Help display affinity group outages by passing cider resource ids to
  * to the access_outages library
  */
-function access_outages_preprocess_views_view(&$vars)
-{
+function access_outages_preprocess_views_view(&$vars) {
   $view = &$vars['view'];
+
+  $msg =  __FUNCTION__ . '() - $view->id() = '  . print_r($view->id(), true)
+    . ' -- ' . basename(__FILE__) . ':' . __LINE__;
+  \Drupal::messenger()->addStatus($msg);
+  // error_log('======= $text = [' . $text . '] -- ' . basename(__FILE__) . ':' . __LINE__);
+
+
+
   if ($view->id() == 'affinity_group' &&  $view->current_display == 'group') {
 
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');
@@ -39,11 +45,13 @@ function access_outages_preprocess_views_view(&$vars)
         }
       }
     }
+    $msg =  __FUNCTION__ . '() - $cider_ids = '  . print_r($cider_ids, true)
+      . ' -- ' . basename(__FILE__) . ':' . __LINE__;
+    \Drupal::messenger()->addStatus($msg);
 
     if (count($cider_resource_ids) > 0) {
       $vars['#attached']['library'][] = 'access_outages/outages_library';
       $vars['#attached']['drupalSettings'] = ['ciderIds' => $cider_resource_ids];
     }
-
   }
 }

--- a/modules/access_outages/css/access_outages.css
+++ b/modules/access_outages/css/access_outages.css
@@ -5,11 +5,11 @@
   padding-bottom: 2px;
 }
 
-.outage-span { 
+.outage-span {
   background-color: white;
-  border-width: 3px; 
-  border-style: solid; 
-  border-color: #777474; 
+  border-width: 3px;
+  border-style: solid;
+  border-color: #777474;
   padding: 4px;
   white-space: nowrap;
 }

--- a/modules/access_outages/js/affinity_group_outages.js
+++ b/modules/access_outages/js/affinity_group_outages.js
@@ -141,10 +141,11 @@ const showPlannedOutages = async function showPlannedOutages(ciderIds, bDebugWit
     // create the html table
     addOutageTableHtmlToDom()
 
-    if (!outagesTable) return; // may not be there when debugging enabled
     const options = {
       timeZoneName: 'short'
     }
+
+    const outagesTable = document.getElementById('ag-outages-planned')
 
     jQuery(outagesTable).DataTable({
       data: filtered,
@@ -178,7 +179,6 @@ const showPlannedOutages = async function showPlannedOutages(ciderIds, bDebugWit
       searching: false
     })
 
-    const outagesTable = document.getElementById('ag-outages-planned')
     outagesTable.style.display = 'block'
   }
 }
@@ -193,7 +193,7 @@ function addOutageTableHtmlToDom() {
     <div class="outage-list section container">
       <div class="row">
         <div class="mb-3">
-          <h3 class="pb-2">Planned Downtimes for Associated Resources</h3>
+          <h3 class="pb-2">Planned Downtimes for Associated Infrastructure</h3>
           <div class="table-responsive">
             <table id="ag-outages-planned" class="display text-start table" style="display:none;">
               <thead>

--- a/modules/access_outages/js/affinity_group_outages.js
+++ b/modules/access_outages/js/affinity_group_outages.js
@@ -73,13 +73,8 @@ const showCurrentOutages = async function showCurrentOutages(ciderIds, bDebugWit
       </div>
     `
 
-    // add the div to the top of the page
-    // (hopefully the following div id doesn't change)
-    //                                          block-views-block-affinity-group-group
-    // let container = document.getElementById('block-views-block-affinity-group-group')
-    // let container = document.getElementById('block-outagesblock')
+    // add the div to the page
     let container = document.getElementById('block-accesstheme-content')
-
     container.insertBefore(outagesCurrentDiv, container.firstChild);
     const outagesCurrent = document.getElementById('outages-current-p')
 

--- a/modules/access_outages/js/affinity_group_outages.js
+++ b/modules/access_outages/js/affinity_group_outages.js
@@ -19,7 +19,9 @@ document.onreadystatechange = function () {
   if (document.readyState == "complete") {
     const ciderIds = drupalSettings.ciderIds
     // only show outages if there are any ciderIds
-    if (ciderIds.length > 0) showAgOutages(ciderIds, bDebugWithAllOutages)
+    if (bDebugWithAllOutages || (ciderIds && ciderIds.length > 0)) {
+      showAgOutages(ciderIds, bDebugWithAllOutages)
+    }
   }
 }
 
@@ -38,38 +40,6 @@ const showAgOutages = async function showAgOutages(ciderIds, bDebugWithAllOutage
 }
 
 /**
- * Add the planned outages table to the DOM
- */
-function addOutageTableHtmlToDom() {
-
-  let outagesTableDiv = document.createElement('div')
-  outagesTableDiv.innerHTML = `<br>
-    <div class="outage-list section container">
-      <div class="row">
-        <div class="mb-3">
-          <h3 class="pb-2">Planned Downtimes</h3>
-          <div class="table-responsive">
-            <table id="outages-planned" class="display text-start table" style="display:none;">
-              <thead>
-                <tr>
-                  <th>Event</th>
-                  <th>Start</th>
-                  <th>End</th>
-                </tr>
-              </thead>
-              <tbody>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  `
-  container = document.getElementById('access_news')
-  container.appendChild(outagesTableDiv, container.firstChild);
-}
-
-/**
  * Current outages are shown in boxes in a div at top of page.
  * Only add the div if there are any associated outages.
  * Make the api call, filter results, and display any outages
@@ -83,12 +53,14 @@ const showCurrentOutages = async function showCurrentOutages(ciderIds, bDebugWit
 
   // for testing, get all outages
   const endpointUrl = bDebugWithAllOutages
-    ? 'https://info.xsede.org/wh1/outages/v1/outages'
-    : 'https://info.xsede.org/wh1/outages/v1/outages/Current'
+    ? 'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/all_outages'
+    : 'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/current_outages'
 
   const response = await fetch(endpointUrl)
   let outages = await response.json()
-  let filtered = filterOutages(outages, ciderIds)
+  let filtered = bDebugWithAllOutages ? outages.results : filterOutages(outages.results, ciderIds)
+
+  if (bDebugWithAllOutages & filtered.length > 4) filtered.length = 4 // keep debugging simple
 
   if (filtered.length > 0) {
 
@@ -102,8 +74,12 @@ const showCurrentOutages = async function showCurrentOutages(ciderIds, bDebugWit
     `
 
     // add the div to the top of the page
-    // (hopefully the following div id is the same on all domains)
-    let container = document.getElementById('block-views-block-affinity-group-group-2')
+    // (hopefully the following div id doesn't change)
+    //                                          block-views-block-affinity-group-group
+    // let container = document.getElementById('block-views-block-affinity-group-group')
+    // let container = document.getElementById('block-outagesblock')
+    let container = document.getElementById('block-accesstheme-content')
+
     container.insertBefore(outagesCurrentDiv, container.firstChild);
     const outagesCurrent = document.getElementById('outages-current-p')
 
@@ -125,7 +101,7 @@ const showCurrentOutages = async function showCurrentOutages(ciderIds, bDebugWit
  */
 function getOutageHtml(outage) {
   return `
-    <a href="https://support.access-ci.org/outages?outageID=` + outage['ID'] + `">
+    <a style="text-decoration: none" href="/outages?outageID=` + outage['URN'] + `">
       <span class="outage-span">
         <span style="color: #f07537; font-size: 170%"> &bull; </span>
         Current Outage
@@ -145,21 +121,27 @@ function getOutageHtml(outage) {
  */
 const showPlannedOutages = async function showPlannedOutages(ciderIds, bDebugWithAllOutages) {
 
+  // only show this on the affinity group view
+  container = document.getElementById('access_news')
+  if (!container) return;
+
   // for testing, get all outages
   const endpointUrl = bDebugWithAllOutages
-    ? 'https://info.xsede.org/wh1/outages/v1/outages'
-    : 'https://info.xsede.org/wh1/outages/v1/outages/Future'
+    ? 'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/all_outages'
+    : 'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/future_outages'
 
   const response = await fetch(endpointUrl)
   let outages = await response.json()
-  let filtered = filterOutages(outages, ciderIds)
+  let filtered = bDebugWithAllOutages ? outages.results : filterOutages(outages.results, ciderIds)
+
+  if (bDebugWithAllOutages & filtered.length > 4) filtered.length = 4
 
   if (filtered.length > 0) {
 
     // create the html table
     addOutageTableHtmlToDom()
 
-    const outagesTable = document.getElementById('outages-planned')
+    if (!outagesTable) return; // may not be there when debugging enabled
     const options = {
       timeZoneName: 'short'
     }
@@ -170,19 +152,23 @@ const showPlannedOutages = async function showPlannedOutages(ciderIds, bDebugWit
         {
           data: 'Subject',
           render: function (data, type, row, meta) {
-            return type === 'display' ? `<a href="https://support.access-ci.org/outages?outageID=${row['ID']}">${data}</a>` : data;
+            return type === 'display' ? `<a href="/outages?outageID=${row['URN']}">${data}</a>` : data;
           }
         },
         {
           data: 'OutageStart',
           render: function (data, type, row, meta) {
-            return type === 'display' ? new Date(data).toLocaleString(navigator.language, options) : data;
+            return type === 'display'
+              ? (data ? new Date(data).toLocaleString(navigator.language, options) : '')
+              : data;
           }
         },
         {
           data: 'OutageEnd',
           render: function (data, type, row, meta) {
-            return type === 'display' ? new Date(data).toLocaleString(navigator.language, options) : data;
+            return type === 'display'
+              ? (data ? new Date(data).toLocaleString(navigator.language, options) : '')
+              : data;
           }
         }
       ],
@@ -191,8 +177,43 @@ const showPlannedOutages = async function showPlannedOutages(ciderIds, bDebugWit
       bAutoWidth: false,
       searching: false
     })
+
+    const outagesTable = document.getElementById('ag-outages-planned')
     outagesTable.style.display = 'block'
   }
+}
+
+/**
+ * Add the planned outages table to the DOM
+ */
+function addOutageTableHtmlToDom() {
+
+  let outagesTableDiv = document.createElement('div')
+  outagesTableDiv.innerHTML = `<br>
+    <div class="outage-list section container">
+      <div class="row">
+        <div class="mb-3">
+          <h3 class="pb-2">Planned Downtimes for Associated Resources</h3>
+          <div class="table-responsive">
+            <table id="ag-outages-planned" class="display text-start table" style="display:none;">
+              <thead>
+                <tr>
+                  <th>Event</th>
+                  <th>Start</th>
+                  <th>End</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+  // only show this on the page that has the access_news container.
+  container = document.getElementById('access_news')
+  container.appendChild(outagesTableDiv, container.firstChild);
 }
 
 /**
@@ -206,10 +227,13 @@ const showPlannedOutages = async function showPlannedOutages(ciderIds, bDebugWit
 function filterOutages(outages, ciderIds) {
   let filtered = []
   Object.keys(outages).forEach(function (key) {
-    if (ciderIds.indexOf(outages[key]['ResourceID']) > -1) {
-      filtered.push(outages[key]);
+    for (const resource of outages[key]['AffectedResources']) {
+      if (ciderIds.indexOf(resource.ResourceID) > -1) {
+        if (filtered.indexOf(outages[key]) === -1) {
+          filtered.push(outages[key]);
+        }
+      }
     }
   });
   return filtered;
 }
-

--- a/modules/access_outages/templates/outages-block.html.twig
+++ b/modules/access_outages/templates/outages-block.html.twig
@@ -112,9 +112,6 @@
         timeZoneName: 'short'
       }
 
-      // bug:  on refresh, DataTable function is missing, don't know why
-      console.log('=== outageName = ' + outageName + ' outagesTable = ' + outagesTable)
-
       jQuery(outagesTable).DataTable({
         data: outages.results,
         columns: [

--- a/modules/access_outages/templates/outages-block.html.twig
+++ b/modules/access_outages/templates/outages-block.html.twig
@@ -79,9 +79,9 @@
   <div class="row">
     <div class="col text-start text-md-center">
       <h2>All Outages</h2>
-      <p id="no-past-outages">Loading past outages...</p>
+      <p id="no-all-outages">Loading all outages...</p>
       <div class="table-responsive">
-        <table id="outages-past" class="display text-start table">
+        <table id="outages-all" class="display text-start table">
             <thead>
                 <tr>
                     <th>Event</th>
@@ -103,35 +103,53 @@
 <script>
   const showOutages = async function showOutages(outageName, endpointUrl) {
     const response = await fetch(endpointUrl)
-    const outages = await response.json()
-    {# console.log(outages) #}
-
-    if (outages.length > 0) {
+    var outages = await response.json()
+    if (outages.results.length > 0) {
       const noOutages = document.getElementById(`no-${outageName}-outages`)
-      noOutages.style.display = 'none' 
+      noOutages.style.display = 'none'
       const outagesTable = document.getElementById('outages-' + outageName)
       const options = {
         timeZoneName: 'short'
       }
+
+      // bug:  on refresh, DataTable function is missing, don't know why
+      console.log('=== outageName = ' + outageName + ' outagesTable = ' + outagesTable)
+
       jQuery(outagesTable).DataTable({
-        data: outages,
+        data: outages.results,
         columns: [
           { data: 'Subject',
             render: function ( data, type, row, meta ) {
-              return type === 'display' ? `<a href="/outages?outageID=${row['ID']}">${data}</a>` : data;
-            }  
+              return type === 'display' ? `<a href="/outages?outageID=${row['URN']}">${data}</a>` : data;
+            }
           },
-          { data: 'ResourceID' },
+          { data: 'AffectedResources',
+            render: function ( data, type, row, meta ) {
+              if (type === 'display') {
+                const copyItems = [];
+                data.forEach(function(item){
+                  copyItems.push(item.ResourceID);
+                })
+                return copyItems.length == 1 ? copyItems[0]
+                  : '&#8231;&nbsp;' + copyItems.join('<br>&#8231;&nbsp;')
+              }
+              return data;
+            }
+          },
           { data: 'Content' },
           { data: 'OutageType' },
           { data: 'OutageStart',
             render: function ( data, type, row, meta ) {
-              return type === 'display' ? new Date(data).toLocaleString(navigator.language, options) : data;
-            } 
+              return type === 'display'
+                ? (data ? new Date(data).toLocaleString(navigator.language, options) : '')
+                : data;
+            }
           },
           { data: 'OutageEnd',
             render: function ( data, type, row, meta ) {
-              return type === 'display' ? new Date(data).toLocaleString(navigator.language, options) : data;
+              return type === 'display'
+                ? (data ? new Date(data).toLocaleString(navigator.language, options) : '')
+                : data;
             }
           }
         ],
@@ -152,30 +170,46 @@
       }
     )
 
-    const response = await fetch(`https://info.xsede.org/wh1/outages/v1/outages/ID/${outageID}`)
+    const url = `https://operations-api.access-ci.org/wh2/news/v1/id/${outageID}`
+    const response = await fetch(url)
     const outage = await response.json()
-    {# console.log(outage) #}
     const loadingOutage = document.getElementById('loading-outage')
-    loadingOutage.style.display = 'none' 
+    loadingOutage.style.display = 'none'
     const outageTable = document.getElementById('outage')
     const options = {
       timeZoneName: 'short'
     }
     jQuery(outageTable).DataTable({
-      data: [outage],
+      data: [outage.results],
       columns: [
         { data: 'Subject' },
-        { data: 'ResourceID' },
-        { data: 'Content' },
-        { data: 'OutageType' },
-        { data: 'OutageStart',
+        { data: 'Associations',
           render: function ( data, type, row, meta ) {
-            return type === 'display' ? new Date(data).toLocaleString(navigator.language, options) : data;
-          } 
+            if (type === 'display') {
+              const copyItems = [];
+              data.forEach(function(item){
+                copyItems.push(item.AssociatedID);
+              })
+              return copyItems.length == 1 ? copyItems[0]
+                : '&#8231;&nbsp;' + copyItems.join('<br>&#8231;&nbsp;')
+            }
+            return data;
+          }
         },
-        { data: 'OutageEnd',
+        { data: 'Content' },
+        { data: 'NewsType' },
+        { data: 'NewsStart',
           render: function ( data, type, row, meta ) {
-            return type === 'display' ? new Date(data).toLocaleString(navigator.language, options) : data;
+            return type === 'display'
+                ? (data ? new Date(data).toLocaleString(navigator.language, options) : '')
+                : data;
+          }
+        },
+        { data: 'NewsEnd',
+          render: function ( data, type, row, meta ) {
+            return type === 'display'
+                ? (data ? new Date(data).toLocaleString(navigator.language, options) : '')
+                : data;
           }
         }
       ],
@@ -191,9 +225,9 @@
   const outageID = url.searchParams.get("outageID")
 
   if (!outageID) {
-    showOutages('current', 'https://info.xsede.org/wh1/outages/v1/outages/Current')
-    showOutages('planned', 'https://info.xsede.org/wh1/outages/v1/outages/Future')
-    showOutages('past',    'https://info.xsede.org/wh1/outages/v1/outages/')
+    showOutages('current', 'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/current_outages/')
+    showOutages('planned', 'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/future_outages/')
+    showOutages('all',     'https://operations-api.access-ci.org/wh2/news/v1/affiliation/access-ci.org/all_outages/')
   } else {
     showOutage(outageID)
   }

--- a/modules/access_outages/templates/outages-block.html.twig
+++ b/modules/access_outages/templates/outages-block.html.twig
@@ -81,7 +81,7 @@
       <h2>All Outages</h2>
       <p id="no-all-outages">Loading all outages...</p>
       <div class="table-responsive">
-        <table id="outages-all" class="display text-start table">
+        <table id="outages-all" class="display text-start table" style="display:none;">
             <thead>
                 <tr>
                     <th>Event</th>
@@ -136,7 +136,12 @@
               return data;
             }
           },
-          { data: 'Content' },
+          { data: 'Content',
+            render: function ( data, type, row, meta ) {
+              return type === 'display'
+                ? `<div style="word-wrap:anywhere">${data}</div>` : data;
+            }
+          },
           { data: 'OutageType' },
           { data: 'OutageStart',
             render: function ( data, type, row, meta ) {
@@ -196,7 +201,12 @@
             return data;
           }
         },
-        { data: 'Content' },
+        { data: 'Content',
+          render: function ( data, type, row, meta ) {
+            return type === 'display'
+              ? `<div style="word-wrap:anywhere">${data}</div>` : data;
+          }
+        },
         { data: 'NewsType' },
         { data: 'NewsStart',
           render: function ( data, type, row, meta ) {


### PR DESCRIPTION
Ready for review.  Changes:

- new endpoints for outages, for both the outages page and affinity group pages.  
- if for ag page, there are bullets displayed if that ag has current outages, and table displayed if that ag has planned outages.  to test this, the user must join AGs that have current or future outages.