### PR TITLE
at line 328, test for empty taxonomyId for the

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -74,7 +74,8 @@ function access_affinitygroup_entity_presave(EntityInterface $entity) {
 
       // If present, remove this AG from this user's block list.
       removeBlockedAG($taxonomyId, $userDetails);
-    } else {
+    }
+    else {
       // Case 2: Affinity group edit was saved by admin user.
       update_ag_leader_roles($entity);
       add_ag_taxonomy_term($entity);
@@ -120,7 +121,8 @@ function access_affinitygroup_entity_presave(EntityInterface $entity) {
 
         if (!empty($list_id)) {
           $entity->set('field_list_id', $list_id);
-        } else {
+        }
+        else {
           showStatus('Bad Constant Contact list id.');
         }
       }
@@ -240,7 +242,8 @@ function update_removed_ag_leader_roles($entity, $coordinator_ids) {
         $user->removeRole('affinity_group_leader');
         $user->save();
         \Drupal::messenger()->addStatus('Removed Affinity Group Leader role for ' . $user->getAccountName());
-      } else {
+      }
+      else {
         \Drupal::messenger()->addStatus('Not removing Affinity Group Leader role for ' . $user->getAccountName()
           . ' because coordinator for another Affinity Group');
       }
@@ -257,7 +260,8 @@ function add_ag_taxonomy_term($entity) {
   $tid = NULL;
   if ($exists) {
     $tid = array_keys(ag_taxonomy_lookup($ag_title))[0];
-  } else {
+  }
+  else {
     $tid = create_ag_taxonomy_term($ag_title);
   }
 
@@ -270,7 +274,7 @@ function add_ag_taxonomy_term($entity) {
  */
 function ag_taxonomy_lookup($ag_title) {
   // Ok to pass null -- returns null if $ag_title is null.
-  // TODO deprecated
+  // @todo deprecated.
   $lookup = taxonomy_term_load_multiple_by_name($ag_title, 'affinity_groups');
   return $lookup;
 }
@@ -294,7 +298,8 @@ function subscribeToCCList($taxonomyId, $userDetails) {
   $postJSON = makeListMembershipJSON($taxonomyId, $userDetails);
   if (empty($postJSON)) {
     showStatus("Can't add user to email list; check if user is missing Constant Contact ID.");
-  } else {
+  }
+  else {
     $cca = new ConstantContactApi();
     $ccResponse = $cca->apiCall('/activities/add_list_memberships', $postJSON, 'POST');
   }
@@ -320,7 +325,10 @@ function access_affinitygroup_entity_delete(EntityInterface $entity) {
       // id is used to find the AG node related to the taxonomy and then the CC
       // list_id within the node for json to send to api.
       $taxonomyId = $entity->get('entity_id')->getValue()[0]['value'];
-      // $refEntArray = $entity->referencedEntities();
+      if (empty($taxonomyId)) {
+        return;
+      }
+
       $currentUser = \Drupal::currentUser();
       $userId = $currentUser->id();
       $userDetails = User::load($userId);
@@ -332,7 +340,8 @@ function access_affinitygroup_entity_delete(EntityInterface $entity) {
       }
       // Put this AG on this user's block list if not already there.
       addBlockedAG($taxonomyId, $userDetails);
-    } else {
+    }
+    else {
       // Case 2: AG getting deleted.
       $title = $entity->getTitle();
       $cca = new ConstantContactApi();
@@ -385,7 +394,8 @@ function removeBlockedAG($agTaxonomyId, $userDetails) {
   foreach ($userBlockedArray as $userBlock) {
     if ($userBlock['target_id'] !== $agTaxonomyId) {
       $userBlockedTaxIds[] = $userBlock['target_id'];
-    } else {
+    }
+    else {
       $wasBlocked = TRUE;
     }
   }
@@ -472,11 +482,13 @@ function access_affinitygroup_user_login(UserInterface $account) {
     $cca_user_id = addUserToConstantContact($current_user->getEmail(), $firstName, $lastName);
     if (empty($cca_user_id)) {
       showStatus("Could not add user to Constant Contact.");
-    } else {
+    }
+    else {
       $user_detail->set('field_constant_contact_id', $cca_user_id);
       $user_detail->save();
     }
-  } else {
+  }
+  else {
     // This else just for debugging in early stages
     // showStatus("Login and NOT attempting add of new constant contact id.");.
   }
@@ -531,7 +543,8 @@ function access_affinitygroup_cron() {
       // $aui->updateUserAllocations();
       // emailDevCronLog(); // this function needs to be fixed.
     }
-  } catch (Exception $e) {
+  }
+  catch (Exception $e) {
     \Drupal::logger('cron_affinitygroup')->notice('exception in cron test: ' . $e->getMessage());
   } finally {
     \Drupal::state()->set('access_affinitygroup.cronrunning', FALSE);
@@ -558,7 +571,8 @@ function shouldRun($function) {
     if ($hoursDiff >= 6) {
       return TRUE;
     }
-  } elseif ($function == 'users') {
+  }
+  elseif ($function == 'users') {
 
     // TEMP TEMP JUST DON'T RUN IMPORT CRON FOR NOW.
     return FALSE;
@@ -634,7 +648,8 @@ function emailToAffinityGroups($emailText, $emailTitle, $pubDate, $agNames, $new
   // Either use email template for access or community.
   if ($communityTemplate) {
     $emailHtml = ccCommunityNewsHTML($emailText, $emailTitle, $pubDate, $agNames, $newsUrl, $logoUrl);
-  } else {
+  }
+  else {
     $emailHtml = ccAccessNewsHTML($emailText, $emailTitle, $pubDate, $agNames, $newsUrl);
   }
 
@@ -709,7 +724,8 @@ function sendEmailCampaign($campaignId, $campaignActivityId, $ccListIds) {
   }
   if ($sent) {
     showStatus("News item emailed to specified affinity groups.");
-  } else {
+  }
+  else {
     showStatus("Error while trying to email news items to affinity groups.");
   }
 }


### PR DESCRIPTION
This is for a case where a user has a flag on a deleted affinity group to prevent downstream crash when
disabling a user.

The code is also formatted (my apologies).  The only non-formatting change is at line 328, where there is a new check for an empty taxonomyId.

https://cyberteamportal.atlassian.net/browse/D8-1460