### PR TITLE
Use content moderation workflow for engagements (D8-1447)

### DIFF
--- a/modules/access_match_engagement/access_match_engagement.install
+++ b/modules/access_match_engagement/access_match_engagement.install
@@ -5,11 +5,50 @@
  * Module updates.
  */
 
+use Drupal\node\Entity\Node;
+
 /**
- * hook_update.
+ * Hook_update.
  */
 function access_match_engagement_update_8001() {
   $config = \Drupal::configFactory()->getEditable('access_match_engagement.settings');
   $config->set('interested', 0);
   $config->save();
+}
+
+/**
+ *
+ */
+function access_match_engagement_update_9001() {
+  // Change status field values to match moderation_state values.
+  $new_status_values = [
+    'Draft' => 'draft',
+    'In Review' => 'in_review',
+    'Accepted' => 'accepted',
+    'Recruiting' => 'recruiting',
+    'Reviewing Applicants' => 'reviewing_applicants',
+    'In Progress' => 'in_progress',
+    'Finishing Up' => 'finishing_up',
+    'Complete' => 'complete',
+    'On Hold' => 'on_hold',
+    'Halted' => 'halted',
+  ];
+
+  $query = \Drupal::database()->select('node_field_data', 'nfd');
+  $query->fields('nfd', ['nid']);
+  $query->condition('nfd.type', 'match_engagement');
+  $result = $query->execute()->fetchAll();
+  $nids = array_column($result, 'nid');
+
+  $nodes = Node::loadMultiple($nids);
+  foreach ($nodes as $node) {
+    $status = $node->get('field_status')->getValue();
+    if ($status) {
+      $status = $status[0]['value'];
+      if (array_key_exists($status, $new_status_values)) {
+        $node->set('field_status', $new_status_values[$status]);
+        $node->save();
+      }
+    }
+  }
 }

--- a/modules/access_match_engagement/access_match_engagement.install
+++ b/modules/access_match_engagement/access_match_engagement.install
@@ -5,7 +5,8 @@
  * Module updates.
  */
 
-use Drupal\node\Entity\Node;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 
 /**
  * Hook_update.
@@ -34,21 +35,54 @@ function access_match_engagement_update_9001() {
     'Halted' => 'halted',
   ];
 
-  $query = \Drupal::database()->select('node_field_data', 'nfd');
-  $query->fields('nfd', ['nid']);
-  $query->condition('nfd.type', 'match_engagement');
-  $result = $query->execute()->fetchAll();
-  $nids = array_column($result, 'nid');
+  $database = \Drupal::database();
+  $entity_type = 'node';
+  $field_name = 'field_status';
+  $table = 'node__field_status';
+  $revision_table = 'node_revision__field_status';
 
-  $nodes = Node::loadMultiple($nids);
-  foreach ($nodes as $node) {
-    $status = $node->get('field_status')->getValue();
-    if ($status) {
-      $status = $status[0]['value'];
-      if (array_key_exists($status, $new_status_values)) {
-        $node->set('field_status', $new_status_values[$status]);
-        $node->save();
-      }
+  // Store existing data in field_status & revision tables.
+  $query = $database->select($table, 't');
+  $query->fields('t', []);
+  $rows = $query->execute()->fetchAll();
+  $query = $database->select($revision_table, 't');
+  $query->fields('t', []);
+  $revision_rows = $query->execute()->fetchAll();
+
+  // Make a copy of field_status field and delete the original.
+  $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
+  $new_fields = [];
+  foreach ($field_storage->getBundles() as $bundle => $label) {
+    $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+    $new_field = $field->toArray();
+    // Add new allowed values.
+    $new_field['allowed_values'] = array_flip($new_status_values);
+    $new_fields[] = $new_field;
+    // Delete field.
+    $field->delete();
+  }
+  field_purge_batch(250);
+
+  // Create new field_status field.
+  FieldStorageConfig::create($field_storage->toArray())->save();
+  foreach ($new_fields as $new_field) {
+    $new_field = FieldConfig::create($new_field);
+    $new_field->save();
+  }
+
+  // Restore existing data in fields & revision tables.
+  if (!is_null($rows)) {
+    foreach ($rows as $row) {
+      $row = (array) $row;
+      $row['field_status_value'] = $new_status_values[$row['field_status_value']];
+      $database->insert($table)->fields($row)->execute();
+    }
+  }
+  if (!is_null($revision_rows)) {
+    foreach ($revision_rows as $row) {
+      $row = (array) $row;
+      $row['field_status_value'] = $new_status_values[$row['field_status_value']];
+      $database->insert($revision_table)->fields($row)->execute();
     }
   }
 }

--- a/modules/access_match_engagement/access_match_engagement.module
+++ b/modules/access_match_engagement/access_match_engagement.module
@@ -5,15 +5,16 @@
  * Module for customizing match_engagement node.
  */
 
+use Drupal\Component\Utility\Xss;
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\user\Entity\User;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
-use Drupal\Component\Utility\Xss;
 use Drupal\Core\Entity\EntityInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\user\Entity\User;
 use Drupal\views\ViewExecutable;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_views_pre_render().
@@ -41,29 +42,23 @@ function access_match_engagement_form_alter(&$form, FormStateInterface $form_sta
   if ($form_id == 'node_match_engagement_edit_form' || $form_id == 'node_match_engagement_form') {
     // Attach javascript.
     $form['#attached']['library'][] = 'access_match_engagement/access_match_engagement';
-    $form['promote']['widget']['value']['#title'] = 'Form Accepted';
-    $form['promote']['widget']['value']['#description'] = 'Once checked, all fields will be available to fill out.';
-    $request = \Drupal::request();
-    $request_type = $request->get("type");
-    // Default to plus if type is unexpected value for node creation.
-    $request_type = $request_type == 'premier' ? 'premier' : 'plus';
-    if ($request_type == 'premier') {
-      $form['#title'] = t('Create Premier Engagement');
-    }
-    if (!isset($request_type) && $form_id != 'node_match_engagement_edit_form') {
-      $url = '/node/add/match_engagement?type=plus';
-      $response = new RedirectResponse($url);
-      $response->send();
-    }
-    $current_user = \Drupal::currentUser();
-    $roles = $current_user->getRoles();
-    $accepted = $form['promote']['widget']['value']['#default_value'];
-    $form['field_node_type']['#access'] = FALSE;
+
+    // If creating a new enagement, use the request type from the url
     if ($form_id == 'node_match_engagement_form') {
+      $request = \Drupal::request();
+      $request_type = $request->get("type");
+      // Default to plus if type is unexpected value for node creation.
+      $request_type = $request_type == 'premier' ? 'premier' : 'plus';
+      if ($request_type == 'premier') {
+        $form['#title'] = t('Create Premier Engagement');
+      }
+      if (!isset($request_type)) {
+        $url = '/node/add/match_engagement?type=plus';
+        $response = new RedirectResponse($url);
+        $response->send();
+      }
       $form['field_node_type']['widget']['#default_value'][0] = $request_type;
     }
-
-    $form['fieldset_launch'] = ['#type' => 'fieldset'];
 
     $form['field-launch-presentation'] = [
       '#group' => 'fieldset_launch',
@@ -78,6 +73,16 @@ function access_match_engagement_form_alter(&$form, FormStateInterface $form_sta
       '#group' => 'fieldset_launch',
     ];
 
+    // Hide status field. We will set automatically with the moderation state.
+    $form['field_status']['#access'] = FALSE;
+
+    $current_user = \Drupal::currentUser();
+    $roles = $current_user->getRoles();
+    $unaccepted_states = ['draft', 'in_review'];
+    $moderation_state = $form['moderation_state']['widget'][0]['state']['#default_value'];
+    $accepted = !in_array($moderation_state, $unaccepted_states);
+
+    // Hide these fields until the engagement is accepted.
     if (!$accepted) {
       $form['field_requested_engagement']['#access'] = FALSE;
       $form['field_project_image']['#access'] = FALSE;
@@ -132,15 +137,22 @@ function access_match_engagement_form_alter(&$form, FormStateInterface $form_sta
       $form['field_match_steering_committee_m']['#access'] = FALSE;
       $form['field_lessons_learned']['#access'] = FALSE;
       $form['field_overall_results']['#access'] = FALSE;
-      $form['field_status']['#access'] = FALSE;
     }
     if (!in_array('administrator', $roles) && !in_array('match_sc', $roles)) {
       $form['field_email_user']['#access'] = FALSE;
       $form['field_notes_to_author']['#access'] = FALSE;
       $form['field_match_interested_users']['#access'] = FALSE;
       $form['field_match_steering_committee_m']['#disabled'] = TRUE;
-      $form['field_status']['#disabled'] = TRUE;
+      $form['field_node_type']['#access'] = FALSE;
+      $form['field_email_user']['#access'] = FALSE;
+      $form['field_notes_to_author']['#acces'] = FALSE;
     }
+    if (in_array('match_sc', $roles)) {
+      // Show author, status, and last saved date to SC.
+      $form['meta']['#access'] = TRUE;
+      unset($form['meta']['#group']);
+    }
+
     if ($form_id == 'node_match_engagement_edit_form') {
       $node_param = \Drupal::routeMatch()->getParameter('node');
       $node_storage = \Drupal::entityTypeManager()->getStorage('node');
@@ -163,16 +175,6 @@ function access_match_engagement_form_alter(&$form, FormStateInterface $form_sta
         $form['field_programming_skill_level']['#access'] = FALSE;
       }
     }
-    $form['field_email_user']['#group'] = 'options';
-    if (in_array('match_sc', $roles)) {
-      unset($form['promote']['#group']);
-      unset($form['field_email_user']['#group']);
-      $form['promote']['#access'] = TRUE;
-      $form['field_email_user']['#access'] = TRUE;
-      $form['status']['#access'] = TRUE;
-    }
-    $form['field_notes_to_author']['#group'] = 'options';
-    $form['field_notes_to_author']['#attributes']['class'][] = 'hide';
   }
   if ($form_id == 'node_match_engagement_form') {
     // Custom Submit handler.
@@ -184,8 +186,8 @@ function access_match_engagement_form_alter(&$form, FormStateInterface $form_sta
  *
  */
 function access_match_engagement_submit_function(&$form, FormStateInterface $form_state) {
-  $message = t('Thank you for submitting your project. We will be in touch soon.');
-  \Drupal::messenger()->addMessage($message);
+  $moderation_state = $form_state->getValues()['moderation_state'][0]['value'];
+  update_drupal_message($moderation_state);
 }
 
 /**
@@ -193,8 +195,7 @@ function access_match_engagement_submit_function(&$form, FormStateInterface $for
  */
 function access_match_engagement_mail($key, &$message, $params) {
   switch ($key) {
-    case 'ame-admin-update':
-    case 'ame-accepted-update':
+    case 'ame-email-notes':
     case 'interested-update':
       $message['from'] = \Drupal::config('system.site')->get('mail');
       $message['subject'] = $params['title'];
@@ -203,19 +204,14 @@ function access_match_engagement_mail($key, &$message, $params) {
   }
 }
 
-/**
- * Implements hook_node_insert().
- */
-function access_match_engagement_node_insert(EntityInterface $entity) {
-  $type = $entity->bundle();
-  if ($type == 'match_engagement') {
-    $get_fields = $entity->getFields();
-    $node_type = $get_fields['field_node_type']->getValue();
-    $ame_type = $node_type[0]['value'] == 'plus' ? '+' : ' Premier';
-    $ame_nid = $entity->id();
-    $ame_title = Xss::filter($entity->gettitle());
-    access_match_engagement_admin_email($ame_nid, $ame_title, $ame_type);
+function update_drupal_message($moderation_state) {
+  if ($moderation_state == 'draft') {
+    $message = t('Thank you for submitting your project. Please change the status to "In Review" when you are ready to submit for review.');
   }
+  elseif ($moderation_state == 'in_review') {
+    $message = t('Thank you for submitting your project. We will be in touch soon.');
+  }
+  \Drupal::messenger()->addMessage($message);
 }
 
 /**
@@ -223,20 +219,27 @@ function access_match_engagement_node_insert(EntityInterface $entity) {
  */
 function access_match_engagement_entity_presave(EntityInterface $entity) {
   $type = $entity->bundle();
-  if ($type == 'match_engagement' && !empty($entity->id())) {
+  if ($type == 'match_engagement') {
     $get_fields = $entity->getFields();
+    // set field_status to moderation_state.
+    $moderation_state = $get_fields['moderation_state']->getValue();
+    if ($moderation_state) {
+      $moderation_state = $moderation_state[0]['value'];
+      $entity->set('field_status', $moderation_state);
+      Cache::invalidateTags($entity->getCacheTagsToInvalidate());
+      update_drupal_message($moderation_state);
+    }
+    // send email to engagement author if field_email_user is checked.
     $email_user = $get_fields['field_email_user']->getValue();
-    $current_user = \Drupal::currentUser()->id();
-    $owner_user = $entity->getOwner();
-    $get_fields = $entity->getFields();
-    $node_type = $get_fields['field_node_type']->getValue();
-    $ame_type = $node_type[0]['value'] == 'plus' ? '+' : ' Premier';
     if ($email_user[0]['value']) {
+      $owner_user = $entity->getOwner();
+      $node_type = $get_fields['field_node_type']->getValue();
+      $ame_type = $node_type[0]['value'] == 'plus' ? '+' : ' Premier';
       $ame_nid = $entity->id();
       $ame_title = Xss::filter($entity->gettitle());
       $ame_notes = $get_fields['field_notes_to_author']->getValue();
       $ame_notes = $ame_notes[0]['value'] ?? '';
-      access_match_engagement_accepted_email($ame_nid, $ame_title, $ame_notes, $owner_user->id(), $ame_type);
+      access_match_engagement_email($ame_nid, $ame_title, $ame_notes, $owner_user->id(), $ame_type);
       $entity->set('field_email_user', 0);
     }
   }
@@ -273,18 +276,16 @@ function access_match_engagement_interested_email($to_uids) {
 }
 
 /**
- * Build access_match_engagement accepted Email.
+ * Build access_match_engagement notes Email.
  */
-function access_match_engagement_accepted_email($ame_nid, $ame_title, $ame_notes, $author, $ame_type) {
+function access_match_engagement_email($ame_nid, $ame_title, $ame_notes, $author, $ame_type) {
   $options = ['absolute' => TRUE];
   $here = Url::fromRoute('entity.node.canonical', ['node' => $ame_nid], $options);
   $body['string'] = [
     '#type' => 'inline_template',
-    '#template' => '<p>{{ intro }}<p>
-    <p>{{ link }}</p>
+    '#template' => '<p>{{ link }}</p>
     <p>{{ notes }}</p>',
     '#context' => [
-      'intro' => t('Your new Match+ Engagement submission has been accepted. Please fill in the rest of this form at your convenience:'),
       'link' => Link::fromTextAndUrl($ame_title, $here)->toString(),
       'notes' => $ame_notes,
     ],
@@ -294,7 +295,8 @@ function access_match_engagement_accepted_email($ame_nid, $ame_title, $ame_notes
   $env = getenv('PANTHEON_ENVIRONMENT');
   if ($env == 'live') {
     $to_email = $node_author->getEmail();
-  } else {
+  }
+  else {
     $to_email = $current_user->getEmail();
   }
   $render_service = \Drupal::service('renderer');
@@ -302,57 +304,7 @@ function access_match_engagement_accepted_email($ame_nid, $ame_title, $ame_notes
   $params['to'] = $to_email;
   $params['body'] = $render_service->render($body);
   $params['title'] = "MATCH$ame_type Engagement: $ame_title";
-  ame_send('ame-accepted-update', $params);
-}
-
-/**
- * Build access_match_engagement admin Email.
- */
-function access_match_engagement_admin_email($ame_nid, $ame_title, $ame_type) {
-  $options = ['absolute' => TRUE];
-  $here = Url::fromRoute('entity.node.canonical', ['node' => $ame_nid], $options);
-  $body['string'] = [
-    '#type' => 'inline_template',
-    '#template' => '<p>{{ intro }}<p>
-    <p>{{ link }}</p>',
-    '#context' => [
-      'intro' => t('A MATCH Engagement has been saved:'),
-      'link' => Link::fromTextAndUrl($ame_title, $here)->toString(),
-    ],
-  ];
-  // Get all user emails with the match_pm or match_sc role.
-  $query = \Drupal::entityQuery('user');
-  $group = $query
-    ->orConditionGroup()
-    ->condition('roles', 'match_pm')
-    ->condition('roles', 'match_sc');
-  $ids = $query->condition($group)
-    ->condition('status', 1)
-    ->execute();
-  $users = User::loadMultiple($ids);
-  $email = '';
-  $user_count = count($users);
-  $iterate = 0;
-  foreach ($users as $user) {
-    $iterate++;
-    $email .= $user->get('mail')->getString();
-    if ($user_count != $iterate) {
-      $email .= ",";
-    }
-  }
-  $current_user = User::load(\Drupal::currentUser()->id());
-  $env = getenv('PANTHEON_ENVIRONMENT');
-  if ($env == 'live') {
-    $to_email = $email;
-  } else {
-    $to_email = $current_user->getEmail();
-  }
-  $render_service = \Drupal::service('renderer');
-  $params = [];
-  $params['to'] = $to_email;
-  $params['body'] = $render_service->render($body);
-  $params['title'] = "MATCH$ame_type Engagement: $ame_title";
-  ame_send('ame-admin-update', $params);
+  ame_send('ame-email-notes', $params);
 }
 
 /**
@@ -372,18 +324,20 @@ function ame_send($key, $params) {
  * Hook_cron.
  */
 function access_match_engagement_cron() {
-  // @todo once working, limit to run on production only.
-  $config = \Drupal::configFactory()->getEditable('access_match_engagement.settings');
-  $interested_status = $config->get('interested');
-  // Send interested email at 1:00am.
-  if ((date('G', time()) == 01) && (date('i', time()) >= 0) && (date('i', time()) < 5) && $interested_status == 1) {
-    // Lookup users by role.
-    $uids = \Drupal::entityQuery('user')
-      ->condition('status', 1)
-      ->condition('roles', 'match_pm')
-      ->execute();
-    access_match_engagement_interested_email($uids);
-    $config->set('interested', 0);
-    $config->save();
+  $env = getenv('PANTHEON_ENVIRONMENT');
+  if ($env == 'live') {
+    $config = \Drupal::configFactory()->getEditable('access_match_engagement.settings');
+    $interested_status = $config->get('interested');
+    // Send interested email at 1:00am.
+    if ((date('G', time()) == 01) && (date('i', time()) >= 0) && (date('i', time()) < 5) && $interested_status == 1) {
+      // Lookup users by role.
+      $uids = \Drupal::entityQuery('user')
+        ->condition('status', 1)
+        ->condition('roles', 'match_pm')
+        ->execute();
+      access_match_engagement_interested_email($uids);
+      $config->set('interested', 0);
+      $config->save();
+    }
   }
 }

--- a/modules/access_match_engagement/js/access_match_engagement.js
+++ b/modules/access_match_engagement/js/access_match_engagement.js
@@ -1,15 +1,7 @@
-var checkBoxPromo = document.getElementById("edit-promote-value");
+var notes = document.getElementById("edit-field-notes-to-author-wrapper");
+notes.classList.add("hide");
+
 var checkBoxEmail = document.getElementById("edit-field-email-user-value");
-
-function checkBoth(chkBoxId, checkBoxWhich) {
-  var element = document.getElementById("edit-field-notes-to-author-wrapper");
-  if (checkBoxWhich.checked == true){
-    document.getElementById(chkBoxId).checked = true;
-    element.classList.remove("hide");
-  } else{
-    element.classList.add("hide");
-  }
-}
-
-checkBoxPromo.onclick = function () {checkBoth('edit-field-email-user-value', checkBoxPromo);};
-checkBoxEmail.onclick = function () {checkBoth('edit-promote-value', checkBoxEmail);};
+checkBoxEmail.onclick = function () {
+  notes.classList.toggle("hide");
+};

--- a/modules/cssn/src/Controller/CommunityPersonaController.php
+++ b/modules/cssn/src/Controller/CommunityPersonaController.php
@@ -44,7 +44,7 @@ class CommunityPersonaController extends ControllerBase {
         $affinity_group_nid = $query->execute()->fetchCol();
         if (isset($affinity_group_nid[0])) {
           $affinity_group_loaded = \Drupal::entityTypeManager()->getStorage('node')->load($affinity_group_nid[0]);
-          $url = Url::fromRoute('entity.node.canonical', array('node' => $affinity_group_loaded->id()));
+          $url = Url::fromRoute('entity.node.canonical', ['node' => $affinity_group_loaded->id()]);
           $project_link = Link::fromTextAndUrl($affinity_group_loaded->getTitle(), $url);
           $link = $project_link->toString()->__toString();
           $user_affinity_groups .= "<li>$link</li>";
@@ -145,7 +145,7 @@ class CommunityPersonaController extends ControllerBase {
       'field_researcher' => 'Researcher',
       'field_match_interested_users' => 'Interested',
     ];
-    $matches = new MatchLookup($fields, $user->id());
+    $matches = new MatchLookup($fields, $user->id(), $public);
     // Sort by status.
     $matches->sortStatusMatches();
     $match_list = $matches->getMatchList();
@@ -196,25 +196,25 @@ class CommunityPersonaController extends ControllerBase {
    * Build content to display on page.
    */
   public function communityPersona() {
-    // My Affinity Groups
+    // My Affinity Groups.
     $current_user = \Drupal::currentUser();
-    // List of affinity groups
+    // List of affinity groups.
     $user_affinity_groups = $this->affinityGroupList($current_user);
-    // Affinity link
+    // Affinity link.
     $build_affinity_link = $this->buildAffinityLink();
-    // My Interests
+    // My Interests.
     $my_interests = $this->buildInterests($current_user);
     // Edit interests link.
     $edit_interest_url = Url::fromUri('internal:/add-interest');
     $edit_interest_link = Link::fromTextAndUrl('Edit interests', $edit_interest_url);
     $edit_interest_renderable = $edit_interest_link->toRenderable();
-    // My Expertise
+    // My Expertise.
     $my_skills = $this->mySkills($current_user);
     // Link to add Skills/Expertise.
     $edit_skill_url = Url::fromUri('internal:/add-skill');
     $edit_skill_link = Link::fromTextAndUrl('Edit expertise', $edit_skill_url);
     $edit_skill_renderable = $edit_skill_link->toRenderable();
-    // My Knowledge Base Contributions
+    // My Knowledge Base Contributions.
     $ws_link = $this->knowledgeBaseContrib($current_user);
 
     // Link to add Knowledge Base Contribution webform.
@@ -223,7 +223,7 @@ class CommunityPersonaController extends ControllerBase {
     $webform_renderable = $webform_link->toRenderable();
     $build_webform_link = $webform_renderable;
     $build_webform_link['#attributes']['class'] = ['btn', 'btn-primary', 'btn-sm', 'py-1', 'px-2'];
-    // My Match Engagements
+    // My Match Engagements.
     $match_link = $this->matchList($current_user);
     // Link to see all Match Engagements.
     $match_engage_url = Url::fromUri('internal:/engagements');
@@ -315,22 +315,23 @@ class CommunityPersonaController extends ControllerBase {
       $user = User::load($user_id);
       if ($user !== NULL) {
         $should_user_load = TRUE;
-      } else {
+      }
+      else {
         $should_user_load = FALSE;
       }
     }
     if ($should_user_load) {
       $user_first_name = $user->get('field_user_first_name')->value;
       $user_last_name = $user->get('field_user_last_name')->value;
-      // List of affinity groups
+      // List of affinity groups.
       $user_affinity_groups = $this->affinityGroupList($user, TRUE);
-      // My Interests
+      // My Interests.
       $my_interests = $this->buildInterests($user, TRUE);
-      // My Expertise
+      // My Expertise.
       $my_skills = $this->mySkills($user, TRUE);
-      // My Knowledge Base Contributions
+      // My Knowledge Base Contributions.
       $ws_link = $this->knowledgeBaseContrib($user, TRUE);
-      // My Match Engagements
+      // My Match Engagements.
       $match_link = $this->matchList($user, TRUE);
 
       $persona_page['#title'] = "$user_first_name $user_last_name";
@@ -388,7 +389,8 @@ class CommunityPersonaController extends ControllerBase {
         ],
       ];
       return $persona_page;
-    } else {
+    }
+    else {
       return [
         '#type' => 'markup',
         '#title' => 'User not found',
@@ -396,4 +398,5 @@ class CommunityPersonaController extends ControllerBase {
       ];
     }
   }
+
 }

--- a/modules/cssn/src/Plugin/Block/PersonaBlock.php
+++ b/modules/cssn/src/Plugin/Block/PersonaBlock.php
@@ -92,7 +92,6 @@ class PersonaBlock extends BlockBase {
       else {
         $academic_status = '';
       }
-      // $academic_status = $academic_terms_map[$academic_status];
       $key = array_search('authenticated', $roles);
       if ($key !== FALSE) {
         unset($roles[$key]);

--- a/modules/cssn/src/Plugin/Block/PersonaBlock.php
+++ b/modules/cssn/src/Plugin/Block/PersonaBlock.php
@@ -85,8 +85,14 @@ class PersonaBlock extends BlockBase {
             ? $user_entity->get('field_academic_status')->value : '';
 
       $academic_terms_map = $user_entity->get('field_academic_status')->getSettings()['allowed_values'];
-      $academic_status = $academic_terms_map[$academic_status];
-
+      // If $academic_status is not empty, map it to the label.
+      if (!empty($academic_status)) {
+        $academic_status = $academic_terms_map[$academic_status];
+      }
+      else {
+        $academic_status = '';
+      }
+      // $academic_status = $academic_terms_map[$academic_status];
       $key = array_search('authenticated', $roles);
       if ($key !== FALSE) {
         unset($roles[$key]);


### PR DESCRIPTION
## Describe context / purpose for this PR
Use a content moderation workflow for MATCH engagements, enabling MATCH SC role to view engagements before they are published. Also enables emails for workflow transitions using the content moderation notification method.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1447

## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/593

## Link to MultiDev instance
http://md-1447-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
