### PR TITLE
D8 1437 test

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -523,7 +523,7 @@ function access_affinitygroup_cron() {
     if (shouldRun('token')) {
       $currentTime = \Drupal::time()->getCurrentTime();
       \Drupal::state()->set('access_affinitygroup.crontime-t', $currentTime);
-      \Drupal::logger('cron_affinitygroup')->notice('Running cron: token' . date("Y-m-d H:i:s", $currentTime));
+      \Drupal::logger('access_affinitygroup')->notice('Running cron: token refresh' . date("Y-m-d H:i:s", $currentTime));
 
       $cca = new ConstantContactApi();
       $cca->newToken();
@@ -559,15 +559,15 @@ function shouldRun($function) {
 
   $currentTime = \Drupal::time()->getCurrentTime();
   if ($function == 'token') {
+    //return TRUE;
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-t', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
-    \Drupal::logger('cron_affinitygroup')->notice("checking $function last "
-                                                . date("Y-m-d H:i:s", $lastRun)
-                                                . " now " . date("Y-m-d H:i:s", $currentTime)
-                                                . "; hours diff $hoursDiff ");
-
+    // \Drupal::logger('cron_affinitygroup')->notice("checking $function last "
+    //                                            . date("Y-m-d H:i:s", $lastRun)
+    //                                            . " now " . date("Y-m-d H:i:s", $currentTime)
+    //                                            . "; hours diff $hoursDiff ");
     // Run if it's been at least 6 hours since the last run.
-    if ($hoursDiff >= 6) {
+    if ($hoursDiff >= 1) {  // 1 for this test only
       return TRUE;
     }
 
@@ -589,10 +589,10 @@ function shouldRun($function) {
 
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-u', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
-    \Drupal::logger('cron_affinitygroup')->notice("checking $function last "
-                                                  . date("Y-m-d H:i:s", $lastRun)
-                                                  . " now " . date("Y-m-d H:i:s", $currentTime)
-                                                  . "; hours diff $hoursDiff ", 'd');
+    //\Drupal::logger('cron_affinitygroup')->notice("checking $function last "
+    //                                              . date("Y-m-d H:i:s", $lastRun)
+    //                                              . " now " . date("Y-m-d H:i:s", $currentTime)
+    //                                              . "; hours diff $hoursDiff ", 'd');
 
     // Run if it's been more than 24 hours since the last run.
     if ($hoursDiff > 24) {

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -559,15 +559,11 @@ function shouldRun($function) {
 
   $currentTime = \Drupal::time()->getCurrentTime();
   if ($function == 'token') {
-    //return TRUE;
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-t', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
-    // \Drupal::logger('cron_affinitygroup')->notice("checking $function last "
-    //                                            . date("Y-m-d H:i:s", $lastRun)
-    //                                            . " now " . date("Y-m-d H:i:s", $currentTime)
-    //                                            . "; hours diff $hoursDiff ");
+
     // Run if it's been at least 6 hours since the last run.
-    if ($hoursDiff >= 1) {  // 1 for this test only
+    if ($hoursDiff >= 6) {
       return TRUE;
     }
 
@@ -589,10 +585,6 @@ function shouldRun($function) {
 
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-u', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
-    //\Drupal::logger('cron_affinitygroup')->notice("checking $function last "
-    //                                              . date("Y-m-d H:i:s", $lastRun)
-    //                                              . " now " . date("Y-m-d H:i:s", $currentTime)
-    //                                              . "; hours diff $hoursDiff ", 'd');
 
     // Run if it's been more than 24 hours since the last run.
     if ($hoursDiff > 24) {

--- a/modules/access_affinitygroup/src/Form/ConstantContact.php
+++ b/modules/access_affinitygroup/src/Form/ConstantContact.php
@@ -13,14 +13,12 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 /**
  * Class ConstantContact.
  */
-class ConstantContact extends FormBase
-{
+class ConstantContact extends FormBase {
 
     /**
      * {@inheritdoc}
      */
-    public function buildForm(array $form, FormStateInterface $form_state)
-    {
+    public function buildForm(array $form, FormStateInterface $form_state) {
         $alloc_cron_disable = \Drupal::state()->get('access_affinitygroup.alloc_cron_disable');
         $alloc_cron_allow_ondemand = \Drupal::state()->get('access_affinitygroup.alloc_cron_allow_ondemand');
 
@@ -34,11 +32,15 @@ class ConstantContact extends FormBase
         $refresh_token = $request->get('refresh_token');
 
         if ($refresh_token) {
+            \Drupal::logger('access_affinitygroup')->notice("Build form Refresh Token".$refresh_token);
+
             $cca = new ConstantContactApi();
             $cca->newToken();
         }
 
         if ($code) {
+            \Drupal::logger('access_affinitygroup')->notice("Build form Code ");
+
             $cca = new ConstantContactApi();
             $cca->initializeToken($code);
         }
@@ -47,118 +49,118 @@ class ConstantContact extends FormBase
         $link = Link::fromTextAndUrl(t('Refresh Token'), $url)->toString()->getGeneratedLink();
 
         $form['scope'] = [
-        '#type' => 'checkboxes',
-        '#options' => [
-        'account_read' => $this->t('Account Read'),
-        'account_update' => $this->t('Account Update'),
-        'contact_data' => $this->t('Contact Data'),
-        'offline_access' => $this->t('Offline Access'),
-        'campaign_data' => $this->t('campaign_data'),
-        ],
-        '#default_value' => [
-        'account_read',
-        'account_update',
-        'contact_data',
-        'offline_access',
-        'campaign_data',
-        ],
-        '#title' => $this->t('Scope'),
-        '#description' => $this->t('Select Constant Contact permissions.'),
+            '#type' => 'checkboxes',
+            '#options' => [
+                'account_read' => $this->t('Account Read'),
+                'account_update' => $this->t('Account Update'),
+                'contact_data' => $this->t('Contact Data'),
+                'offline_access' => $this->t('Offline Access'),
+                'campaign_data' => $this->t('campaign_data'),
+            ],
+            '#default_value' => [
+                'account_read',
+                'account_update',
+                'contact_data',
+                'offline_access',
+                'campaign_data',
+            ],
+            '#title' => $this->t('Scope'),
+            '#description' => $this->t('Select Constant Contact permissions.'),
         ];
 
         $form['submit'] = [
-        '#type' => 'submit',
-        '#value' => $this->t('Authorize App'),
-        '#submit' => [[$this, 'submitForm']],
+            '#type' => 'submit',
+            '#value' => $this->t('Authorize App'),
+            '#submit' => [[$this, 'submitForm']],
         ];
 
         $form['refresh_token'] = [
-        '#markup' => $link,
+            '#markup' => $link,
         ];
 
         $form['x1'] = [
-        '#markup' => '<br><br><b>Administration Allocations Import Cron Settings</b>',
+            '#markup' => '<br><br><b>Administration Allocations Import Cron Settings</b>',
         ];
 
         $form['alloc_cron_disable'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Disable Allocations Import Cron'),
-        '#description' => $this->t('Unchecked is the normal value.'),
-        '#default_value' => $alloc_cron_disable,
+            '#type' => 'checkbox',
+            '#title' => $this->t('Disable Allocations Import Cron'),
+            '#description' => $this->t('Unchecked is the normal value.'),
+            '#default_value' => $alloc_cron_disable,
         ];
 
         $form['alloc_cron_allow_ondemand'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Allow Allocation Import Cron On-Demand'),
-        '#description' => $this->t('Unchecked is the normal value.'),
-        '#default_value' => $alloc_cron_allow_ondemand,
+            '#type' => 'checkbox',
+            '#title' => $this->t('Allow Allocation Import Cron On-Demand'),
+            '#description' => $this->t('Unchecked is the normal value.'),
+            '#default_value' => $alloc_cron_allow_ondemand,
         ];
 
         $form['savecronsettings'] = [
-        '#type' => 'submit',
-        '#value' => $this->t('Save Cron Settings'),
-        '#submit' => [[$this, 'doSaveCronSettings']],
+            '#type' => 'submit',
+            '#value' => $this->t('Save Cron Settings'),
+            '#submit' => [[$this, 'doSaveCronSettings']],
         ];
 
         $form['x2'] = [
-        '#markup' => '<br><br><b>Import allocations batch processing</b><br>',
+            '#markup' => '<br><br><b>Import allocations batch processing</b><br>',
         ];
 
-         $form['batch_param_batchsize'] = [
-        '#type' => 'number',
-        '#title' => $this->t('Batch Size'),
-        '#min' => 5,
-        '#max' => 1000,
-        '#default_value' => $allocBatchBatchSize,
-        '#description' => $this->t("Size of each batch slice."),
-        '#required' => false,
-         ];
+        $form['batch_param_batchsize'] = [
+            '#type' => 'number',
+            '#title' => $this->t('Batch Size'),
+            '#min' => 5,
+            '#max' => 1000,
+            '#default_value' => $allocBatchBatchSize,
+            '#description' => $this->t("Size of each batch slice."),
+            '#required' => false,
+        ];
 
-         $form['batch_param_importlimit'] = [
-         '#type' => 'number',
-         '#title' => $this->t('Process limit'),
-         '#default_value' => $allocBatchImportLimit,
-         '#description' => $this->t("Limit allocations users processed, up to 105000."),
-         '#required' => false,
-         ];
-         $form['batch_param_startat'] = [
-         '#type' => 'number',
-         '#title' => $this->t('Process start at'),
-         '#default_value' => $allocBatchStartAt,
-         '#description' => $this->t("Start procssing nth user (default: 0)"),
-         '#required' => false,
-         ];
-         $form['batch_param_nocc'] = [
-         '#type' => 'checkbox',
-         '#title' => $this->t('Do not add users to Constant Contact.'),
-         '#description' => $this->t('Unchecked is the normal value.'),
-         '#default_value' => $allocBatchNoCC,
-         ];
+        $form['batch_param_importlimit'] = [
+            '#type' => 'number',
+            '#title' => $this->t('Process limit'),
+            '#default_value' => $allocBatchImportLimit,
+            '#description' => $this->t("Limit allocations users processed, up to 105000."),
+            '#required' => false,
+        ];
+        $form['batch_param_startat'] = [
+            '#type' => 'number',
+            '#title' => $this->t('Process start at'),
+            '#default_value' => $allocBatchStartAt,
+            '#description' => $this->t("Start procssing nth user (default: 0)"),
+            '#required' => false,
+        ];
+        $form['batch_param_nocc'] = [
+            '#type' => 'checkbox',
+            '#title' => $this->t('Do not add users to Constant Contact.'),
+            '#description' => $this->t('Unchecked is the normal value.'),
+            '#default_value' => $allocBatchNoCC,
+        ];
 
-         $form['savebatchsettings'] = [
-         '#type' => 'submit',
-         '#value' => $this->t('Save Batch Settings'),
-         '#submit' => [[$this, 'doSaveBatchSettings']],
-         ];
+        $form['savebatchsettings'] = [
+            '#type' => 'submit',
+            '#value' => $this->t('Save Batch Settings'),
+            '#submit' => [[$this, 'doSaveBatchSettings']],
+        ];
 
-         $form['runBatch'] = [
-                  '#type' => 'submit',
-                  '#value' => $this->t('Start Batch'),
-                  '#description' => $this->t("Start allocations import batch processing"),
-                  '#submit' => [[$this, 'doBatch']],
+        $form['runBatch'] = [
+            '#type' => 'submit',
+            '#value' => $this->t('Start Batch'),
+            '#description' => $this->t("Start allocations import batch processing"),
+            '#submit' => [[$this, 'doBatch']],
         ];
 
 
-                  $form['x4'] = [
-                  '#markup' => '<br><br><b>Weekly Digest</b><br>',
-                  ];
+        $form['x4'] = [
+            '#markup' => '<br><br><b>Weekly Digest</b><br>',
+        ];
 
-                  $form['runNewsDigest'] = [
-                  '#type' => 'submit',
-                  '#value' => $this->t('Generate Digest'),
-                  '#submit' => [[$this, 'doGenerateDigest']],
-                  ];
-                  return $form;
+        $form['runNewsDigest'] = [
+            '#type' => 'submit',
+            '#value' => $this->t('Generate Digest'),
+            '#submit' => [[$this, 'doGenerateDigest']],
+        ];
+        return $form;
     }
 
     /**
@@ -167,8 +169,7 @@ class ConstantContact extends FormBase
      * @return string
      *   The unique ID of the form defined by this class.
      */
-    public function getFormId()
-    {
+    public function getFormId() {
         return 'constantcontact_form';
     }
 
@@ -180,8 +181,7 @@ class ConstantContact extends FormBase
      * @param \Drupal\Core\Form\FormStateInterface $form_state
      *   Object describing the current state of the form.
      */
-    public function validateForm(array &$form, FormStateInterface $form_state)
-    {
+    public function validateForm(array &$form, FormStateInterface $form_state) {
         $value_check = array_filter($form_state->getValue('scope'));
         if (empty($value_check)) {
             $form_state->setErrorByName('access_affinitygroup', 'Select at least one checkbox under scope.');
@@ -191,8 +191,7 @@ class ConstantContact extends FormBase
     /**
      * {@inheritdoc}
      */
-    public function submitForm(array &$form, FormStateInterface $form_state)
-    {
+    public function submitForm(array &$form, FormStateInterface $form_state) {
         $selected_scope = '';
         foreach ($form_state->getValue('scope') as $scope_value) {
             if ($scope_value !== 0) {
@@ -211,28 +210,24 @@ class ConstantContact extends FormBase
         parent::submitForm($form, $form_state);
     }
 
-    public function doSaveBatchSettings(array &$form, FormStateInterface $form_state)
-    {
+    public function doSaveBatchSettings(array &$form, FormStateInterface $form_state) {
         \Drupal::state()->set('access_affinitygroup.allocBatchBatchSize', $form_state->getValue('batch_param_batchsize'));
         \Drupal::state()->set('access_affinitygroup.allocBatchImportLimit', $form_state->getValue('batch_param_importlimit'));
         \Drupal::state()->set('access_affinitygroup.allocBatchNoCC', $form_state->getValue('batch_param_nocc'));
         \Drupal::state()->set('access_affinitygroup.allocBatchStartAt', $form_state->getValue('batch_param_startat'));
     }
 
-    public function doSaveCronSettings(array &$form, FormStateInterface $form_state)
-    {
+    public function doSaveCronSettings(array &$form, FormStateInterface $form_state) {
         \Drupal::state()->set('access_affinitygroup.alloc_cron_disable', $form_state->getValue('alloc_cron_disable'));
         \Drupal::state()->set('access_affinitygroup.alloc_cron_allow_ondemand', $form_state->getValue('alloc_cron_allow_ondemand'));
     }
 
     // generate the access_news weekly digest (normally run weekly via cron)
-    public function doGenerateDigest()
-    {
+    public function doGenerateDigest() {
         weeklyNewsReport(true);
     }
 
-    public function doBatch()
-    {
+    public function doBatch() {
         $aui = new AllocationsUsersImport();
         $aui->startBatch();
     }

--- a/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
+++ b/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
@@ -43,15 +43,23 @@ class ConstantContactApi {
    * Function to sort the curl headers.
    */
   public function __construct() {
+    try {
     $config_factory = \Drupal::configFactory();
     $this->configSettings = $config_factory->getEditable('access_affinitygroup.settings');
     $this->accessToken = $this->configSettings->get('access_token');
     $this->refreshToken = $this->configSettings->get('refresh_token');
+    \Drupal::logger('access_affinitygroup')->notice('cca constructor get R:' . $this->refreshToken);
+    \Drupal::logger('access_affinitygroup')->notice('cca constructor get A:' . $this->accessToken);
+
     $cc_key = trim(\Drupal::service('key.repository')->getKey('constant_contact_client_id')->getKeyValue());
     $this->clientId = urlencode($cc_key);
     $key_secret = trim(\Drupal::service('key.repository')->getKey('constant_contact_client_secret')->getKeyValue());
     $this->clientSecret = urlencode($key_secret);
     $this->supressErrDisplay = FALSE;
+    }
+    catch (Exception $e) {
+      \Drupal::logger('access_affinitygroup')->notice('Exception in constantContactApi constructor: ' . $e->getMessage());
+    }
   }
 
   /**
@@ -81,6 +89,7 @@ class ConstantContactApi {
    * Initialize Constant Contact Token.
    */
   public function initializeToken($code) {
+    try {
     $clientId = $this->clientId;
     $clientSecret = $this->clientSecret;
     $host = \Drupal::request()->getSchemeAndHttpHost();
@@ -89,22 +98,37 @@ class ConstantContactApi {
     $returned_token = $this->getAccessToken($redirectURI, $clientId, $clientSecret, $code);
     $returned_token = json_decode($returned_token);
 
+    if (isset($returned_token->error)) {
+      \Drupal::logger('access_affinitygroup')->notice("cc init token err set, error, desc: " . $returned_token->error_description);
+    }
+    if ($returned_token) {
+      \Drupal::logger('access_affinitygroup')->notice("cc init token RF: " . $returned_token->refresh_token);
+    } else {
+      \Drupal::logger('access_affinitygroup')->notice("cc init token RT NOT");
+    }
+
     if ($returned_token && !isset($returned_token->error)) {
       $this->setAccessToken($returned_token->access_token);
       $this->setRefreshToken($returned_token->refresh_token);
+      \Drupal::logger('access_affinitygroup')->notice("cc init r/a: " . $returned_token->refresh_token . " / " . $returned_token->access_token);
       \Drupal::logger('access_affinitygroup')->notice("Constant Contact: new access_token and refresh_token stored");
       \Drupal::messenger()->addMessage("Constant Contact: new access_token and refresh_token stored");
-    }
-    else {
+    } else {
       $this->apiError($returned_token->error, $returned_token->error_description);
     }
+  } catch (Exception $e) {
+      \Drupal::logger('access_affinitygroup')->notice("cc init token exception: " . $e->getMessage());
+  }
   }
 
   /**
    * Refresh Constant Contact Token and set new ones.
    */
   public function newToken() {
+    try {
     $refreshToken = $this->refreshToken;
+
+    \Drupal::logger('access_affinitygroup')->notice('New token prev R: ' . $refreshToken);
     $clientId = $this->clientId;
     $clientSecret = $this->clientSecret;
     // Use cURL to get a new access token and refresh token.
@@ -135,19 +159,25 @@ class ConstantContactApi {
     $result = curl_exec($ch);
     $result = json_decode($result);
 
-    // $httpCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
-    // @todo might want to check code here too in case result is not formed
+    $httpCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    \Drupal::logger('access_affinitygroup')->notice('New token httpCode: ' . $httpCode);
     curl_close($ch);
 
     if (!isset($result->error)) {
       $this->setAccessToken($result->access_token);
       $this->setRefreshToken($result->refresh_token);
+      \Drupal::logger('access_affinitygroup')->notice('New token N: ' . $result->refresh_token);
       \Drupal::logger('access_affinitygroup')->notice("Constant Contact: new access_token and refresh_token stored");
       \Drupal::messenger()->addMessage("Constant Contact: new access_token and refresh_token stored");
     }
     else {
+      \Drupal::logger('access_affinitygroup')->error('New token: error');
 
       $this->apiError($result->error, $result->error_description);
+    }
+    }
+    catch (Exception $e) {
+      \Drupal::logger('access_affinitygroup')->notice('Exception in new token: ' . $e->getMessage());
     }
   }
 


### PR DESCRIPTION
## Describe context / purpose for this PR
Contains a lot of extra logging and defenses in a quest to understand why the cron-run refresh of the Constant Contact authorization, where we get new access and refresh tokens does not always succeed. Currently an error is logged coming back from constant contact that have an invalid grant. I have seen that this is the error that we will see if we hand in an garbage refresh token. Currently I suspect that we lose the token along the line and are using a null refresh token to reauthorize.

The only change that is not logging or try/catch blocks is doing a refresh from cron after 1 hour interval instead of 6 hours.

Ready for merging. Access branch d9-1437 is back to the 6 hour token interval.
Issue link
https://cyberteamportal.atlassian.net/browse/D8-1437

Any other related PRs?

Link to MultiDev instance
http://md-1437-accessmatch.pantheonsite.io/

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
