### PR TITLE
Rebrand news as announcements

### DIFF
--- a/modules/access_news/src/Plugin/Block/NewsAndEventsBlock.php
+++ b/modules/access_news/src/Plugin/Block/NewsAndEventsBlock.php
@@ -5,11 +5,11 @@ namespace Drupal\access_news\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 
 /**
- * Provides a 'Latest New and Events' Block.
+ * Provides a 'Latest Announcements and Events' Block.
  *
  * @Block(
  *   id = "newsandevents_block",
- *   admin_label = @Translation("News and Events block"),
+ *   admin_label = @Translation("Announcements and Events block"),
  *   category = @Translation("ACCESS"),
  * )
  */
@@ -24,12 +24,14 @@ class NewsAndEventsBlock extends BlockBase {
     $latest_events_block = views_embed_view('recurring_events_event_instances', 'latest_events_block');
 
     return [
-      ['description' => [
-        '#theme' => 'newsandevents_block',
-        '#latest_news_block' => $latest_news_block,
-        '#latest_events_block' => $latest_events_block,
-        ]
-      ]
+      [
+        'description' => [
+          '#theme' => 'newsandevents_block',
+          '#latest_news_block' => $latest_news_block,
+          '#latest_events_block' => $latest_events_block,
+        ],
+      ],
     ];
   }
+
 }

--- a/modules/access_news/src/Plugin/Block/RequestNewsBlock.php
+++ b/modules/access_news/src/Plugin/Block/RequestNewsBlock.php
@@ -5,11 +5,11 @@ namespace Drupal\access_news\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 
 /**
- * Provides a 'Request News' Block.
+ * Provides a 'Request Announcement' Block.
  *
  * @Block(
  *   id = "requestnews_block",
- *   admin_label = @Translation("Request a News Post block"),
+ *   admin_label = @Translation("Request an Announcement block"),
  *   category = @Translation("ACCESS"),
  * )
  */

--- a/modules/access_news/templates/newsandevents-block.html.twig
+++ b/modules/access_news/templates/newsandevents-block.html.twig
@@ -23,9 +23,9 @@
 <div class="news-and-events container my-4">
 	<div class="row g-3">
 		<div class="news col bg-light p-4 me-md-4">
-			<h3>Latest News</h3>
+			<h3>Latest Announcements</h3>
 			{{ latest_news_block }}
-			<a class="d-block mt-3" href="/news">All News</a>
+			<a class="d-block mt-3" href="/news">All Announcements</a>
 		</div>
 		<div class="col-12 col-md-6 bg-light p-4">
 			<h3>Upcoming Events</h3>

--- a/modules/access_news/templates/requestnews-block.html.twig
+++ b/modules/access_news/templates/requestnews-block.html.twig
@@ -1,7 +1,7 @@
 <div class="card mt-2">
 <div class="card-body">
-<h3 class="card-title">Posting News</h3>
+<h3 class="card-title">Posting Announcements</h3>
 
-<p>Do you have news you would like to share with the ACCESS community?</p>
-<a class="btn btn-outline-secondary" href="/node/add/access_news">Add News</a></div>
+<p>Do you have an announcement you would like to share with the ACCESS community?</p>
+<a class="btn btn-outline-secondary" href="/node/add/access_news">Add Announcement</a></div>
 </div>


### PR DESCRIPTION
## Describe context / purpose for this PR
Rebrand news as announcements

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1494

## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/612

## Link to MultiDev instance
http://md-1494-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
