### PR TITLE
update news link to announcements

### DIFF
--- a/modules/access_news/templates/newsandevents-block.html.twig
+++ b/modules/access_news/templates/newsandevents-block.html.twig
@@ -25,7 +25,7 @@
 		<div class="news col bg-light p-4 me-md-4">
 			<h3>Latest Announcements</h3>
 			{{ latest_news_block }}
-			<a class="d-block mt-3" href="/news">All Announcements</a>
+			<a class="d-block mt-3" href="/announcements">All Announcements</a>
 		</div>
 		<div class="col-12 col-md-6 bg-light p-4">
 			<h3>Upcoming Events</h3>


### PR DESCRIPTION
## Describe context / purpose for this PR
Update the link for announcements to /announcements instead of /news
## Issue link
done in conjunction with https://cyberteamportal.atlassian.net/browse/D8-1351

## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/639

## Link to MultiDev instance

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
