### PR TITLE
Sync AG CC error

### DIFF
--- a/modules/access_affinitygroup/src/Plugin/AllocationsUsersImport.php
+++ b/modules/access_affinitygroup/src/Plugin/AllocationsUsersImport.php
@@ -331,6 +331,12 @@ class AllocationsUsersImport {
           $newCiderRefnums = [];
           foreach ($aUser['resources'] as $cider) {
 
+            // special:  there is not a cider resource for this even though
+            // it can be listed on users' allocations list.
+            if ($cider['cider_resource_id'] == 'credits.allocations.access-ci.org') {
+              continue;
+            }
+
             $query = \Drupal::entityQuery('node');
             $refnum = $query
               ->condition('type', 'access_active_resources_from_cid')
@@ -740,7 +746,6 @@ class AllocationsUsersImport {
             $ccId = $field_val[0]['value'];
             $agContacts[] = $ccId;
           }
-
           else {
             // Users without cc id. might not do anything with this here, not sure yet.
             $agContactsNoCCid[] = $uid;
@@ -766,14 +771,17 @@ class AllocationsUsersImport {
         $this->collectCronLog("Sync: to be added to list $agTitle count: " . count($notInCC), 'i');
 
         if (count($notInCC)) {
+          $notInCC = array_values($notInCC);
+
           $postData = [
             'source' => [
-              'contact_ids' => $notInCC
+              'contact_ids' => $notInCC,
             ],
             'list_ids' => [$listId],
           ];
 
-          $cca->apiCall('/activities/add_list_memberships', json_encode($postData), 'POST');
+          $postData = json_encode($postData);
+          $cca->apiCall('/activities/add_list_memberships', $postData, 'POST');
         }
       }
       catch (\Exception $e) {


### PR DESCRIPTION
Fix Constant Contact err due to formatting issue on list add api call.
Also, small change for logging for
allocations import: do not log
on missing cider for
credits.allocation.access-ci.org

## Describe context / purpose for this PR
I wrote the code for syncing constant contact and affinity group membership.  It worked when
hooked up to my personal CC account, but we got a 500 error when hooked up to the production 
CC account. I worked with CC support, who suggested a change in the data format we were sending
to the api when adding a person to a CC list.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1378

## Any other related PRs?

## Link to MultiDev instance

http://md-sync-cc-accessmatch.pantheonsite.io

## Checklist for PR author
- [x ] I have checked that the PR is ready to be merged
- [ x] I have reviewed the DIFF and checked that the changes are as expected
- [x ] I have assigned myself or someone else to review the PR
