### PR TITLE
add host name to logging for constant contact refresh token

### DIFF
--- a/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
+++ b/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
@@ -188,18 +188,21 @@ class ConstantContactApi {
       \Drupal::logger('access_affinitygroup')->notice('New token httpCode: ' . $httpCode);
       curl_close($ch);
 
+      $host = \Drupal::request()->getSchemeAndHttpHost();
+
       if (!isset($result->error)) {
         $this->setAccessToken($result->access_token);
         $this->setRefreshToken($result->refresh_token);
         \Drupal::logger('access_affinitygroup')->notice('New token N: ' . $result->refresh_token);
-        \Drupal::logger('access_affinitygroup')->notice("Constant Contact: new access_token and refresh_token stored");
+        \Drupal::logger('access_affinitygroup')->notice("Constant Contact: new access_token and refresh_token stored $host");
         \Drupal::messenger()->addMessage("Constant Contact: new access_token and refresh_token stored");
       }
       else {
-        \Drupal::logger('access_affinitygroup')->error('New token: error');
+
+        \Drupal::logger('access_affinitygroup')->error("New token error; host $host");
         $this->apiError($result->error, $result->error_description);
         $nr = new NotifyRoles();
-        $nr->notifyRole('site_developer', 'Constant Contact error.', 'New token error. See logs for access_affinitygroup.');
+        $nr->notifyRole('site_developer', 'Constant Contact error.', "New token error at host $host. See logs for access_affinitygroup.");
       }
     }
     catch (\Exception $e) {


### PR DESCRIPTION
## Describe context / purpose for this PR
Simple change to add host name to logging for Constant Contact refresh token.
This may help us understand CC token refresh problems. 
I did not create an MD for this.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1437

## Any other related PRs?

## Link to MultiDev instance

## Checklist for PR author
- [x ] I have checked that the PR is ready to be merged
- [x ] I have reviewed the DIFF and checked that the changes are as expected
- [x ] I have assigned myself or someone else to review the PR
