### PR TITLE
AG edit - ciders field readonly. d8-1527

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -845,9 +845,23 @@ function sendEmailCampaign($campaignId, $campaignActivityId, $ccListIds) {
 
 /**
  * Hook_form_alter.
+ *
+ * For one of two form types:
+ * 1) node_affinity_group_edit_form:  Make the cider resources field read-only
+ *    for non-administrator users.
+ * 2) webform_submission_affinity_group_contact_add_form: sets up form for
+ *    sending one email to affinity group.
  */
 function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ($form_id == 'webform_submission_affinity_group_contact_add_form') {
+
+  if ($form_id == 'node_affinity_group_edit_form') {
+    $current_user = \Drupal::currentUser();
+    $roles = $current_user->getRoles();
+    if (!in_array('administrator', $roles)) {
+      $form['field_cider_resources']['#disabled'] = TRUE;
+    }
+  }
+  elseif ($form_id == 'webform_submission_affinity_group_contact_add_form') {
     $form_allowed = FALSE;
     $coordinator = FALSE;
     // Allow this form only if the node is an affinity group.


### PR DESCRIPTION
## Describe context / purpose for this PR
on affinity group edit, disallow edit on cider resources field for non-admin

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1527

## Any other related PRs?
cyberteam #734 (no change except to pull in this branch)

## Link to MultiDev instance

http://md-1527-accessmatch.pantheonsite.io

## Checklist for PR author
- [x ] I have checked that the PR is ready to be merged
- [ x] I have reviewed the DIFF and checked that the changes are as expected
- [ x] I have assigned myself or someone else to review the PR
