### PR TITLE
New Recommended Resources field on Affinity Groups -1528

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -860,6 +860,16 @@ function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state,
     if (!in_array('administrator', $roles)) {
       $form['field_cider_resources']['#disabled'] = TRUE;
     }
+
+    // only AG set to Community should see Reccomended Ciders;
+    // only AG set to ACCESS RP category should see Associated Ciders
+    $category = $form['field_affinity_group_category']['widget']['#default_value'];
+    if (!isset($category[0]) || $category[0] !== 'Community') {
+      $form['field_recommended_access_res']['#access'] = FALSE;
+    }
+    if (!isset($category[0]) || $category[0] !== 'ACCESS_RP') {
+      $form['field_cider_resources']['#access'] = FALSE;
+    }
   }
   elseif ($form_id == 'webform_submission_affinity_group_contact_add_form') {
     $form_allowed = FALSE;

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -912,6 +912,49 @@ function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state,
 }
 
 /**
+ * Implements hook_inline_entity_form_table_fields_alter().
+ */
+function access_affinitygroup_inline_entity_form_table_fields_alter(&$fields, $context) {
+  //\Drupal::logger('cron_affinitygroup')->notice("context[entity_type]" . $context['entity_type']);
+  //kint($context);
+  //die();
+
+  if ($context['entity_type'] == 'node') {
+    // add the resource field to the table
+
+    $fields['field_cider_resource'] = [
+      'type' => 'field',
+      'label' => t('Resource'),
+      'weight' => 100,
+    ];
+
+    $fields['body'] = [
+      'type' => 'field',
+      'label' => t('Description'),
+      'weight' => 200,
+    ];
+
+    // Hide the status + title field that Inline Entity Form usually displays
+    unset($fields['status']);
+    unset($fields['title']);  // this doesn't work.
+  }
+}
+
+// could use this to set the class. might not need this, bc already has the
+// class node-affinity-group-edit-form
+function access_affinitygroup_field_widget_form_alter(&$element, &$form_state, $context) {
+
+ // kint($context);
+ // die();
+//  \Drupal::logger('cron_affinitygroup')->notice("context[field][type]" . $context['field']['type']);
+  // Add a css class to widget form elements for all fields of type mytype.
+  //if ($context['field']['type'] == 'mytype') {  // not here any more
+
+    // Be sure not to overwrite existing attributes.
+//    $element['#attributes']['class'][] = 'myclass';
+ // }
+}
+/**
  * FAPI validation handler.
  */
 function webform_submission_affinity_group_affinity_contact_validate(&$form, FormStateInterface $form_state) {

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -915,45 +915,24 @@ function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state,
  * Implements hook_inline_entity_form_table_fields_alter().
  */
 function access_affinitygroup_inline_entity_form_table_fields_alter(&$fields, $context) {
-  //\Drupal::logger('cron_affinitygroup')->notice("context[entity_type]" . $context['entity_type']);
-  //kint($context);
-  //die();
+if ($context['entity_type'] == 'node') {
+  // Add the resource field to the table.
+  $fields['field_cider_resource'] = [
+    'type' => 'field',
+    'label' => t('Resource'),
+    'weight' => 100,
+  ];
 
-  if ($context['entity_type'] == 'node') {
-    // add the resource field to the table
+  $fields['body'] = [
+    'type' => 'field',
+    'label' => t('Description'),
+    'weight' => 200,
+  ];
 
-    $fields['field_cider_resource'] = [
-      'type' => 'field',
-      'label' => t('Resource'),
-      'weight' => 100,
-    ];
-
-    $fields['body'] = [
-      'type' => 'field',
-      'label' => t('Description'),
-      'weight' => 200,
-    ];
-
-    // Hide the status + title field that Inline Entity Form usually displays
-    unset($fields['status']);
-    unset($fields['title']);  // this doesn't work.
-  }
+  // Hide the status field that Inline Entity Form usually displays.
+  unset($fields['status']);
 }
 
-// could use this to set the class. might not need this, bc already has the
-// class node-affinity-group-edit-form
-function access_affinitygroup_field_widget_form_alter(&$element, &$form_state, $context) {
-
- // kint($context);
- // die();
-//  \Drupal::logger('cron_affinitygroup')->notice("context[field][type]" . $context['field']['type']);
-  // Add a css class to widget form elements for all fields of type mytype.
-  //if ($context['field']['type'] == 'mytype') {  // not here any more
-
-    // Be sure not to overwrite existing attributes.
-//    $element['#attributes']['class'][] = 'myclass';
- // }
-}
 /**
  * FAPI validation handler.
  */

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -915,22 +915,23 @@ function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state,
  * Implements hook_inline_entity_form_table_fields_alter().
  */
 function access_affinitygroup_inline_entity_form_table_fields_alter(&$fields, $context) {
-if ($context['entity_type'] == 'node') {
-  // Add the resource field to the table.
-  $fields['field_cider_resource'] = [
-    'type' => 'field',
-    'label' => t('Resource'),
-    'weight' => 100,
-  ];
+  if ($context['entity_type'] == 'node') {
+    // Add the resource field to the table.
+    $fields['field_cider_resource'] = [
+      'type' => 'field',
+      'label' => t('Resource'),
+      'weight' => 100,
+    ];
 
-  $fields['body'] = [
-    'type' => 'field',
-    'label' => t('Description'),
-    'weight' => 200,
-  ];
+    $fields['body'] = [
+      'type' => 'field',
+      'label' => t('Description'),
+      'weight' => 200,
+    ];
 
-  // Hide the status field that Inline Entity Form usually displays.
-  unset($fields['status']);
+    // Hide the status field that Inline Entity Form usually displays.
+    unset($fields['status']);
+  }
 }
 
 /**

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -847,8 +847,9 @@ function sendEmailCampaign($campaignId, $campaignActivityId, $ccListIds) {
  * Hook_form_alter.
  *
  * For one of two form types:
- * 1) node_affinity_group_edit_form:  Make the cider resources field read-only
- *    for non-administrator users.
+ * 1) node_affinity_group_edit_form:
+ *  -- Make the associated cider resources field read-only for non-administrator users
+ *  -- hide recommended + associated cider resources fields depending on category
  * 2) webform_submission_affinity_group_contact_add_form: sets up form for
  *    sending one email to affinity group.
  */
@@ -861,8 +862,8 @@ function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state,
       $form['field_cider_resources']['#disabled'] = TRUE;
     }
 
-    // only AG set to Community should see Reccomended Ciders;
-    // only AG set to ACCESS RP category should see Associated Ciders
+    // Only AGs set to Community should see Reccomended Ciders;
+    // only AGs set to ACCESS RP category should see Associated Ciders.
     $category = $form['field_affinity_group_category']['widget']['#default_value'];
     if (!isset($category[0]) || $category[0] !== 'Community') {
       $form['field_recommended_access_res']['#access'] = FALSE;
@@ -922,11 +923,28 @@ function access_affinitygroup_form_alter(&$form, FormStateInterface $form_state,
 }
 
 /**
+ * Hook_presave only for Recommended Cider field.
+ */
+function access_affinitygroup_node_presave(NodeInterface $node) {
+  $type = $node->getType();
+  if ($type == 'recommended_cider') {
+    $node->setTitle('');
+  }
+
+}
+
+/**
  * Implements hook_inline_entity_form_table_fields_alter().
  */
 function access_affinitygroup_inline_entity_form_table_fields_alter(&$fields, $context) {
   if ($context['entity_type'] == 'node') {
-    // Add the resource field to the table.
+
+    // Hide the status + title (aka 'label' here) fields
+    // that Inline Entity Form usually displays.
+    unset($fields['status']);
+    unset($fields['label']);
+
+    // Add the resource + description field to the table.
     $fields['field_cider_resource'] = [
       'type' => 'field',
       'label' => t('Resource'),
@@ -938,10 +956,14 @@ function access_affinitygroup_inline_entity_form_table_fields_alter(&$fields, $c
       'label' => t('Description'),
       'weight' => 200,
     ];
-
-    // Hide the status field that Inline Entity Form usually displays.
-    unset($fields['status']);
   }
+}
+
+/**
+ * When the user is editing a Recommened Resource, hide the title field.
+ */
+function access_affinitygroup_inline_entity_form_entity_form_alter(&$form, &$form_state) {
+  $form['title']['#access'] = FALSE;
 }
 
 /**


### PR DESCRIPTION
Add a new Recommended Resources field on Affinity Groups. Only visible on 
AGs of the Community Category.  A new widget had been added to the project.
We use this widget for the AG edit form where the user will add, edit, or delete a 
Recommended Resource for their group.  There is a new content type which 
contains both  a reference to an Access Cider Resource, and a user-entered description
(Presumably the reason they are recommending this resource to their group.)
NoteL this branch is d-1528a.  (not 1528)
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1528

## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/757

## Link to MultiDev instance
http://md-1528a-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the changes.

