### PR TITLE
in affinity group/constant contact cron, check for support.access-ci.org - cc-cron-block-domains

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -613,12 +613,21 @@ function access_affinitygroup_cron() {
     // Cronrunning true means allocations cron Todo, rename.
     \Drupal::state()->set('access_affinitygroup.cronrunning', FALSE);
 
+    // Make sure we are not somehow on the support domain, This is crucial for
+    // the constant contact connection.
+    $host = \Drupal::request()->getHttpHost();
+    if ($host !== 'support.access-ci.org') {
+      // Temp logging.
+      \Drupal::logger('cron_affinitygroup')->debug("On $host: blocked Constant Contact cron");
+      return;
+    }
+
     // 1. Refresh the Constant Contact Token
     if (shouldRun('token')) {
 
       $currentTime = \Drupal::time()->getCurrentTime();
       \Drupal::state()->set('access_affinitygroup.crontime-t', $currentTime);
-      \Drupal::logger('access_affinitygroup')->notice('Running cron: token refresh' . date("Y-m-d H:i:s", $currentTime));
+      \Drupal::logger('access_affinitygroup')->notice('Cron: token refresh ' . date("Y-m-d H:i:s", $currentTime . " on $host"));
 
       $cca = new ConstantContactApi();
       $cca->newToken();


### PR DESCRIPTION
in affinity group cron for constant contact, check that we
are on support.access-ci.org before proceeding


## Issue link
Trying to fix the invalid access token problem when refreshing constant contact token from cron.

## Any other related PRs?
## Link to MultiDev instance
Did not make a md since we can't test it anyway there. Please let me know if I should make one.

http://md-{{ ticket number }}-accessmatch.pantheonsite.io

## Checklist for PR author
- [ x] I have checked that the PR is ready to be merged
- [x ] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
