### PR TITLE
In access-affinitygroup module, cron hook runs allocations import slices d8-1938

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -104,11 +104,12 @@ function access_affinitygroup_entity_view(array &$build, EntityInterface $entity
  *    Ensure every Affinity Group name has a corresponding taxonomy term.
  */
 function access_affinitygroup_entity_presave(EntityInterface $entity) {
+
   $type = $entity->bundle();
   // Email any infrastructure news with the 'Email only subscribers' box checked.
   if ($type == 'infrastructure_news') {
     $inf_title = $entity->get('title')->getValue()[0]['value'];
-    $inf_body = $entity->get('body') !== null ? $entity->get('body')->getValue()[0]['value'] : '';
+    $inf_body = $entity->get('body') !== NULL ? $entity->get('body')->getValue()[0]['value'] : '';
     $doEmailSubscribers = $entity->get('field_do_email_subscribers')->getValue();
     if ($doEmailSubscribers[0]['value']) {
       $affectedInfrastructure = $entity->get('field_affected_infrastructure')->getValue();
@@ -139,17 +140,20 @@ function access_affinitygroup_entity_presave(EntityInterface $entity) {
   if ($type == 'affinity_group') {
 
     if (method_exists($entity, 'getFlaggableType')) {
-      // Case 1: User did Join the AG (using the Join button or link)
-      // Exit if CRON because this hook assumes there is a current user.
-      if (\Drupal::state()->get('access_affinitygroup.allocationsRun')) {
-        return;
-      }
 
+      // Case 1: User did Join the AG (using the Join button or link)
       // The flag sits on a taxonomy; the taxonomy id is used to find the AG node
       // which we need to build the JSON to send to api.
       $taxonomyId = $entity->get('entity_id')->getValue()[0]['value'];
       $currentUser = \Drupal::currentUser();
       $userId = $currentUser->id();
+
+      // Need to exit if we are here during the allocations import processing,
+      // which can either be run via cron or from admin setting it off on the
+      // constant contact admin form.
+      if ($userId === 1 || $userId === 0) {
+        return;
+      }
       $userDetails = User::load($userId);
       subscribeToCCList($taxonomyId, $userDetails);
 
@@ -658,7 +662,7 @@ function access_affinitygroup_cron() {
 
       $currentTime = \Drupal::time()->getCurrentTime();
       \Drupal::state()->set('access_affinitygroup.crontime-t', $currentTime);
-      \Drupal::logger('access_affinitygroup')->notice('Cron: token refresh ' .  date("Y-m-d H:i:s", $currentTime) . " on $host");
+      \Drupal::logger('access_affinitygroup')->notice('Cron: token refresh ' . date("Y-m-d H:i:s", $currentTime) . " on $host");
 
       $cca = new ConstantContactApi();
       $cca->newToken();

--- a/modules/access_affinitygroup/access_affinitygroup.module
+++ b/modules/access_affinitygroup/access_affinitygroup.module
@@ -25,6 +25,7 @@
  * title changes.
  */
 
+use Drupal\access_affinitygroup\Plugin\AllocationsUsersImport;
 use Drupal\access_affinitygroup\Plugin\ConstantContactApi;
 use Drupal\block\Entity\Block;
 use Drupal\Component\Utility\Xss;
@@ -645,14 +646,10 @@ function showStatus($logmsg) {
  */
 function access_affinitygroup_cron() {
   try {
-    // Cronrunning true means allocations cron Todo, rename.
-    \Drupal::state()->set('access_affinitygroup.cronrunning', FALSE);
-
-    // Make sure we are not somehow on the support domain, This is crucial for
+    // Make sure we are on the support domain, This is crucial for
     // the constant contact connection.
     $host = \Drupal::request()->getHttpHost();
     if ($host !== 'support.access-ci.org') {
-      // Temp logging.
       \Drupal::logger('cron_affinitygroup')->debug("On $host: blocked Constant Contact cron");
       return;
     }
@@ -671,21 +668,17 @@ function access_affinitygroup_cron() {
     // 2. call xdusage api to get users and create/update their
     // allocations and associated affinity groups.
     if (shouldRun('users')) {
-      \Drupal::state()->set('access_affinitygroup.cronrunning', TRUE);
       $currentTime = \Drupal::time()->getCurrentTime();
       \Drupal::state()->set('access_affinitygroup.crontime-u', $currentTime);
-      \Drupal::logger('cron_affinitygroup')->notice('Running cron: user' . date("Y-m-d H:i:s", $currentTime));
+      \Drupal::logger('cron_affinitygroup')->notice('Running cron: alloc imports' . date("Y-m-d H:i:s", $currentTime));
 
-      // @todo this will probably be $aui->startBatch();
-      // $aui = new AllocationsUsersImport();
-      // $aui->updateUserAllocations();
-      // emailDevCronLog(); // this function needs to be fixed.
+      // Run one slice of the imports; parameters are state variables.
+      $aui = new AllocationsUsersImport();
+      $aui->runCronSlice();
     }
   }
   catch (Exception $e) {
-    \Drupal::logger('cron_affinitygroup')->notice('exception in cron test: ' . $e->getMessage());
-  } finally {
-    \Drupal::state()->set('access_affinitygroup.cronrunning', FALSE);
+    \Drupal::logger('cron_affinitygroup')->notice('exception in cron: ' . $e->getMessage());
   }
 }
 
@@ -699,7 +692,7 @@ function shouldRun($function) {
   if ($function == 'token') {
 
     if (!isCCEnabled()) {
-      return;
+      return FALSE;
     }
 
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-t', 0);
@@ -712,24 +705,22 @@ function shouldRun($function) {
   }
   elseif ($function == 'users') {
 
-    // TEMP TEMP JUST DON'T RUN IMPORT CRON FOR NOW.
-    return FALSE;
-    // showStatus("disable: ". \Drupal::state()->get('access_affinitygroup.alloc_cron_disable', false) );
-    // showStatus("allw_ond: ".  \Drupal::state()->get('access_affinitygroup.alloc_cron_allow_ondemand', false) );
-    // These 2 environment booleans are off by default but can be set in the
-    // Constant Contact admin page.
-    if (\Drupal::state()->get('access_affinitygroup.alloc_cron_disable', FALSE)) {
+    if (\Drupal::state()->get('access_affinitygroup.allocCronDisable', FALSE)) {
       return FALSE;
-    }
-    if (\Drupal::state()->get('access_affinitygroup.alloc_cron_allow_ondemand', FALSE)) {
-      return TRUE;
     }
 
     $lastRun = \Drupal::state()->get('access_affinitygroup.crontime-u', 0);
     $hoursDiff = round(($currentTime - $lastRun) / 3600, 1);
+    $hour = date('H', $currentTime);
 
-    // Run if it's been more than 24 hours since the last run.
-    if ($hoursDiff > 24) {
+    $startAt = \Drupal::state()->get('access_affinitygroup.allocCronStartAt', 0);
+
+    // If the start is 0 but we alaready started running alloctions today, we are done.
+    if (date('Ymd') === date('Ymd', $lastRun) && $startAt === 0) {
+      return FALSE;
+    }
+    // Only run if the hour is inclusively between 1 and 5 am.
+    if ($hour >= 1 && $hour <= 5) {
       return TRUE;
     }
   }

--- a/modules/access_affinitygroup/src/Commands/AffinityGroupCommands.php
+++ b/modules/access_affinitygroup/src/Commands/AffinityGroupCommands.php
@@ -179,7 +179,6 @@ class AffinityGroupCommands extends DrushCommands {
       $userIds = $this->getUserIdsFromFlags($term->entity);
       $this->output()->writeln('Members count: ' . count($userIds));
 
-
       if ($headOnly) {
         continue;
       }
@@ -423,12 +422,12 @@ class AffinityGroupCommands extends DrushCommands {
    *
    * @aliases importAllocations
    * @usage   access_affinitygroup:importAllocations
+   * Runs the function the cron would run, using settings
+   * set at the constant contact admin form.
    */
   public function importAllocations() {
     $aui = new AllocationsUsersImport();
-    $retval = $aui->startBatch();
-
-    $this->output()->writeln($retval);
+    $aui->runCronSlice();
   }
 
   /**

--- a/modules/access_affinitygroup/src/Form/ConstantContact.php
+++ b/modules/access_affinitygroup/src/Form/ConstantContact.php
@@ -23,9 +23,8 @@ class ConstantContact extends FormBase {
     $allocCronDisable = \Drupal::state()->get('access_affinitygroup.allocCronDisable');
     $allocCronAllowOndemand = \Drupal::state()->get('access_affinitygroup.allocCronAllowOndemand');
 
-    $allocCronSliceSize = \Drupal::state()->get('access_affinitygroup.allocCronSliceSize'); /* def need */
-    $allocCronImportLimit = \Drupal::state()->get('access_affinitygroup.allocCronImportLimit'); /* might not need */
-    // This should be display only:
+    $allocCronSliceSize = \Drupal::state()->get('access_affinitygroup.allocCronSliceSize');
+    // This will soon be display only:
     $allocCronStartAt = \Drupal::state()->get('access_affinitygroup.allocCronStartAt');
     $allocCronNoCC = \Drupal::state()->get('access_affinitygroup.allocCronNoCC');
     $allocCronNoUserDetSave = \Drupal::state()->get('access_affinitygroup.allocCronNoUserDetSave');
@@ -116,7 +115,7 @@ class ConstantContact extends FormBase {
     /* MANUAL IMPORT ALLOCATIONS BATCH */
 
     $form['y3'] = [
-      '#markup' => '<br><br><h4>Administration Allocations Import Cron Settings</h4>',
+      '#markup' => '<br><br><h4>Allocations Import Cron Settings</h4>',
     ];
 
     $form['alloc_cron_disable'] = [
@@ -141,14 +140,7 @@ class ConstantContact extends FormBase {
       '#description' => $this->t("Number to process on on each cron run."),
       '#required' => FALSE,
     ];
-    /* We prob won't use this one: */
-    $form['alloc_cron_param_importlimit'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Process limit'),
-      '#default_value' => $allocCronImportLimit,
-      '#description' => $this->t("Limit number of users processed."),
-      '#required' => FALSE,
-    ];
+    /* set this to display-only for normal operations */
     $form['alloc_cron_param_startat'] = [
       '#type' => 'number',
       '#title' => $this->t('Process start at'),
@@ -183,8 +175,8 @@ class ConstantContact extends FormBase {
 
     $form['runCron'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Run Cron Slice'),
-      '#description' => $this->t("Dev test: Run one cron slice "),
+      '#value' => $this->t('Run Cron Slice test'),
+      '#description' => $this->t("Dev test only: Run one cron slice "),
       '#submit' => [[$this, 'doCronSlice']],
     ];
 
@@ -192,6 +184,9 @@ class ConstantContact extends FormBase {
 
     $form['y4'] = [
       '#markup' => '<br><br><h4>Run an import allocations batch</h4>',
+    ];
+    $form['i4'] = [
+      '#markup' => 'For user id 1 only',
     ];
 
     $form['batch_param_batchsize'] = [
@@ -412,13 +407,15 @@ class ConstantContact extends FormBase {
       $form_state->getValue('batch_param_verbose')
     );
   }
+
   /**
-   * Dev - if run cron on demand needed, uncomment run cron button
+   * Dev - if run cron on demand needed, uncomment run cron button.
    */
   public function doCronSlice() {
     $aui = new AllocationsUsersImport();
     $aui->runCronSlice();
   }
+
   /**
    * Run the affinity group / constant contact membership list sync.
    */

--- a/modules/access_affinitygroup/src/Form/ConstantContact.php
+++ b/modules/access_affinitygroup/src/Form/ConstantContact.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\access_affinitygroup\Form;
 
-use Drupal\access_affinitygroup\Plugin\ConstantContactApi;
 use Drupal\access_affinitygroup\Plugin\AllocationsUsersImport;
-use Drupal\Core\Form\FormStateInterface;
+use Drupal\access_affinitygroup\Plugin\ConstantContactApi;
 use Drupal\Core\Form\FormBase;
-use Drupal\Core\Url;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -20,14 +20,16 @@ class ConstantContact extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
-    $alloc_cron_disable = \Drupal::state()->get('access_affinitygroup.alloc_cron_disable');
-    $alloc_cron_allow_ondemand = \Drupal::state()->get('access_affinitygroup.alloc_cron_allow_ondemand');
+    $allocCronDisable = \Drupal::state()->get('access_affinitygroup.allocCronDisable');
+    $allocCronAllowOndemand = \Drupal::state()->get('access_affinitygroup.allocCronAllowOndemand');
 
-    $allocBatchBatchSize = \Drupal::state()->get('access_affinitygroup.allocBatchBatchSize');
-    $allocBatchImportLimit = \Drupal::state()->get('access_affinitygroup.allocBatchImportLimit');
-    $allocBatchStartAt = \Drupal::state()->get('access_affinitygroup.allocBatchStartAt');
-    $allocBatchNoCC = \Drupal::state()->get('access_affinitygroup.allocBatchNoCC');
-    $allocBatchNoUserDetSav = \Drupal::state()->get('access_affinitygroup.allocBatchNoUserDetSave');
+    $allocCronSliceSize = \Drupal::state()->get('access_affinitygroup.allocCronSliceSize'); /* def need */
+    $allocCronImportLimit = \Drupal::state()->get('access_affinitygroup.allocCronImportLimit'); /* might not need */
+    // This should be display only:
+    $allocCronStartAt = \Drupal::state()->get('access_affinitygroup.allocCronStartAt');
+    $allocCronNoCC = \Drupal::state()->get('access_affinitygroup.allocCronNoCC');
+    $allocCronNoUserDetSave = \Drupal::state()->get('access_affinitygroup.allocCronNoUserDetSave');
+    $allocCronVerbose = \Drupal::state()->get('access_affinitygroup.allocCronVerbose');
 
     $noConstantContactCalls = \Drupal::configFactory()->getEditable('access_affinitygroup.settings')->get('noConstantContactCalls');
 
@@ -97,91 +99,6 @@ class ConstantContact extends FormBase {
       '#value' => $this->t('Save Disable Setting'),
       '#submit' => [[$this, 'doSaveDisableCC']],
     ];
-
-    $form['y3'] = [
-      '#markup' => '<br><br><h4>Administration Allocations Import Cron Settings</h4>',
-    ];
-
-    $form['alloc_cron_disable'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Disable Allocations Import Cron'),
-      '#description' => $this->t('Unchecked is the normal value.'),
-      '#default_value' => $alloc_cron_disable,
-    ];
-
-    $form['alloc_cron_allow_ondemand'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Allow Allocation Import Cron On-Demand'),
-      '#description' => $this->t('Unchecked is the normal value.'),
-      '#default_value' => $alloc_cron_allow_ondemand,
-    ];
-
-    $form['savecronsettings'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Save Cron Settings'),
-      '#submit' => [[$this, 'doSaveCronSettings']],
-    ];
-
-    $form['y4'] = [
-      '#markup' => '<br><br><h4>Import allocations manual batch</h4>',
-    ];
-
-    $form['batch_param_batchsize'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Batch Size'),
-      '#min' => 5,
-      '#max' => 1000,
-      '#default_value' => $allocBatchBatchSize,
-      '#description' => $this->t("Size of each batch slice."),
-      '#required' => FALSE,
-    ];
-
-    $form['batch_param_importlimit'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Process limit'),
-      '#default_value' => $allocBatchImportLimit,
-      '#description' => $this->t("Limit number of users processed."),
-      '#required' => FALSE,
-    ];
-    $form['batch_param_startat'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Process start at'),
-      '#default_value' => $allocBatchStartAt,
-      '#description' => $this->t("Start procssing nth user (default: 0)"),
-      '#required' => FALSE,
-    ];
-    $form['batch_param_nocc'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Do not add users to Constant Contact.'),
-      '#description' => $this->t('Unchecked is the normal value.'),
-      '#default_value' => $allocBatchNoCC,
-    ];
-    $form['batch_param_nouserdetsave'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Do not save user detail changes.'),
-      '#description' => $this->t('Unchecked is the normal value.'),
-      '#default_value' => $allocBatchNoUserDetSav,
-    ];
-    $form['batch_param_verbose'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Verbose logging'),
-      '#default_value' => FALSE,
-      '#required' => FALSE,
-    ];
-
-    $form['savebatchsettings'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Save Batch Settings'),
-      '#submit' => [[$this, 'doSaveBatchSettings']],
-    ];
-
-    $form['runBatch'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Start Batch'),
-      '#description' => $this->t("Start allocations import batch processing"),
-      '#submit' => [[$this, 'doBatch']],
-    ];
-
     $form['y5'] = [
       '#markup' => '<br><br><h4>Generate Weekly Digest</h4>',
     ];
@@ -195,6 +112,139 @@ class ConstantContact extends FormBase {
       '#value' => $this->t('Generate Digest'),
       '#submit' => [[$this, 'doGenerateDigest']],
     ];
+
+    /* MANUAL IMPORT ALLOCATIONS BATCH */
+
+    $form['y3'] = [
+      '#markup' => '<br><br><h4>Administration Allocations Import Cron Settings</h4>',
+    ];
+
+    $form['alloc_cron_disable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable Allocations Import Cron'),
+      '#description' => $this->t('Unchecked is the normal value.'),
+      '#default_value' => $allocCronDisable,
+    ];
+
+    /* prob don't need this one */
+    $form['alloc_cron_allow_ondemand'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow Allocation Import Cron On-Demand'),
+      '#description' => $this->t('Unchecked is the normal value.'),
+      '#default_value' => $allocCronAllowOndemand,
+    ];
+
+    $form['alloc_cron_param_slicesize'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Slice Size'),
+      '#default_value' => $allocCronSliceSize,
+      '#description' => $this->t("Number to process on on each cron run."),
+      '#required' => FALSE,
+    ];
+    /* We prob won't use this one: */
+    $form['alloc_cron_param_importlimit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Process limit'),
+      '#default_value' => $allocCronImportLimit,
+      '#description' => $this->t("Limit number of users processed."),
+      '#required' => FALSE,
+    ];
+    $form['alloc_cron_param_startat'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Process start at'),
+      '#default_value' => $allocCronStartAt,
+      '#description' => $this->t("Start procssing nth user (default: 0)"),
+      '#required' => FALSE,
+    ];
+    $form['alloc_cron_param_nocc'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Do not add users to Constant Contact.'),
+      '#description' => $this->t('Unchecked is the normal value.'),
+      '#default_value' => $allocCronNoCC,
+    ];
+    $form['alloc_cron_param_nouserdetsave'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Do not save user detail changes.'),
+      '#description' => $this->t('Unchecked is the normal value.'),
+      '#default_value' => $allocCronNoUserDetSave,
+    ];
+    $form['alloc_cron_param_verbose'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Verbose logging'),
+      '#default_value' => $allocCronVerbose,
+      '#required' => FALSE,
+    ];
+
+    $form['savecronsettings'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save Cron Settings'),
+      '#submit' => [[$this, 'doSaveCronSettings']],
+    ];
+
+    $form['runCron'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Run Cron Slice'),
+      '#description' => $this->t("Dev test: Run one cron slice "),
+      '#submit' => [[$this, 'doCronSlice']],
+    ];
+
+    /* MANUAL IMPORT ALLOCATIONS BATCH */
+
+    $form['y4'] = [
+      '#markup' => '<br><br><h4>Run an import allocations batch</h4>',
+    ];
+
+    $form['batch_param_batchsize'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Batch Size'),
+      '#min' => 5,
+      '#max' => 1000,
+      '#default_value' => 100,
+      '#description' => $this->t("Size of each batch slice."),
+      '#required' => FALSE,
+    ];
+
+    $form['batch_param_importlimit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Process limit'),
+      '#default_value' => 5000,
+      '#description' => $this->t("Limit number of users processed."),
+      '#required' => FALSE,
+    ];
+    $form['batch_param_startat'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Process start at'),
+      '#default_value' => 0,
+      '#description' => $this->t("Start procssing nth user (default: 0)"),
+      '#required' => FALSE,
+    ];
+    $form['batch_param_nocc'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Do not add users to Constant Contact.'),
+      '#description' => $this->t('Unchecked is the normal value.'),
+      '#default_value' => TRUE,
+    ];
+    $form['batch_param_nouserdetsave'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Do not save user detail changes.'),
+      '#description' => $this->t('Unchecked is the normal value.'),
+      '#default_value' => TRUE,
+    ];
+    $form['batch_param_verbose'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Verbose logging'),
+      '#default_value' => FALSE,
+      '#required' => FALSE,
+    ];
+
+    $form['runBatch'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Start Batch'),
+      '#description' => $this->t("Start allocations import batch processing"),
+      '#submit' => [[$this, 'doBatch']],
+    ];
+
+    /* SYNC */
 
     $form['y6'] = [
       '#markup' => '<br><br><h4>Sync Constant Constact Lists</h4>',
@@ -327,22 +377,18 @@ class ConstantContact extends FormBase {
   }
 
   /**
-   * Save state variables for running and testing the allocations import batching according to checkbox  values.
-   */
-  public function doSaveBatchSettings(array &$form, FormStateInterface $form_state) {
-    \Drupal::state()->set('access_affinitygroup.allocBatchBatchSize', $form_state->getValue('batch_param_batchsize'));
-    \Drupal::state()->set('access_affinitygroup.allocBatchImportLimit', $form_state->getValue('batch_param_importlimit'));
-    \Drupal::state()->set('access_affinitygroup.allocBatchNoCC', $form_state->getValue('batch_param_nocc'));
-    \Drupal::state()->set('access_affinitygroup.allocBatchNoUserDetSave', $form_state->getValue('batch_param_nouserdetsave'));
-    \Drupal::state()->set('access_affinitygroup.allocBatchStartAt', $form_state->getValue('batch_param_startat'));
-  }
-
-  /**
-   * *  save state variables for running and testing the allocations import cron according to checkbox  values.
+   * Save state variables for running and testing the allocations import cron job according to checkbox values.
    */
   public function doSaveCronSettings(array &$form, FormStateInterface $form_state) {
-    \Drupal::state()->set('access_affinitygroup.alloc_cron_disable', $form_state->getValue('alloc_cron_disable'));
-    \Drupal::state()->set('access_affinitygroup.alloc_cron_allow_ondemand', $form_state->getValue('alloc_cron_allow_ondemand'));
+    \Drupal::state()->set('access_affinitygroup.allocCronDisable', $form_state->getValue('alloc_cron_disable'));
+    \Drupal::state()->set('access_affinitygroup.allocCronAllowOndemand', $form_state->getValue('alloc_cron_allow_ondemand'));
+
+    \Drupal::state()->set('access_affinitygroup.allocCronSliceSize', $form_state->getValue('alloc_cron_param_slicesize'));
+    \Drupal::state()->set('access_affinitygroup.allocCronImportLimit', $form_state->getValue('alloc_cron_param_importlimit'));
+    \Drupal::state()->set('access_affinitygroup.allocCronNoCC', $form_state->getValue('alloc_cron_param_nocc'));
+    \Drupal::state()->set('access_affinitygroup.allocCronNoUserDetSave', $form_state->getValue('alloc_cron_param_nouserdetsave'));
+    \Drupal::state()->set('access_affinitygroup.allocCronStartAt', $form_state->getValue('alloc_cron_param_startat'));
+    \Drupal::state()->set('access_affinitygroup.allocCronVerbose', $form_state->getValue('alloc_cron_param_verbose'));
   }
 
   /**
@@ -353,15 +399,26 @@ class ConstantContact extends FormBase {
   }
 
   /**
-   *
+   * Set off the allocations import with the batch api.
    */
   public function doBatch(array &$form, FormStateInterface $form_state) {
     $aui = new AllocationsUsersImport();
     $aui->startBatch(
+      $form_state->getValue('batch_param_batchsize'),
+      $form_state->getValue('batch_param_importlimit'),
+      $form_state->getValue('batch_param_nocc'),
+      $form_state->getValue('batch_param_nouserdetsave'),
+      $form_state->getValue('batch_param_startat'),
       $form_state->getValue('batch_param_verbose')
     );
   }
-
+  /**
+   * Dev - if run cron on demand needed, uncomment run cron button
+   */
+  public function doCronSlice() {
+    $aui = new AllocationsUsersImport();
+    $aui->runCronSlice();
+  }
   /**
    * Run the affinity group / constant contact membership list sync.
    */

--- a/modules/access_affinitygroup/src/Form/ConstantContact.php
+++ b/modules/access_affinitygroup/src/Form/ConstantContact.php
@@ -21,7 +21,6 @@ class ConstantContact extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     $allocCronDisable = \Drupal::state()->get('access_affinitygroup.allocCronDisable');
-    $allocCronAllowOndemand = \Drupal::state()->get('access_affinitygroup.allocCronAllowOndemand');
 
     $allocCronSliceSize = \Drupal::state()->get('access_affinitygroup.allocCronSliceSize');
     // This will soon be display only:
@@ -123,14 +122,6 @@ class ConstantContact extends FormBase {
       '#title' => $this->t('Disable Allocations Import Cron'),
       '#description' => $this->t('Unchecked is the normal value.'),
       '#default_value' => $allocCronDisable,
-    ];
-
-    /* prob don't need this one */
-    $form['alloc_cron_allow_ondemand'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Allow Allocation Import Cron On-Demand'),
-      '#description' => $this->t('Unchecked is the normal value.'),
-      '#default_value' => $allocCronAllowOndemand,
     ];
 
     $form['alloc_cron_param_slicesize'] = [
@@ -376,8 +367,6 @@ class ConstantContact extends FormBase {
    */
   public function doSaveCronSettings(array &$form, FormStateInterface $form_state) {
     \Drupal::state()->set('access_affinitygroup.allocCronDisable', $form_state->getValue('alloc_cron_disable'));
-    \Drupal::state()->set('access_affinitygroup.allocCronAllowOndemand', $form_state->getValue('alloc_cron_allow_ondemand'));
-
     \Drupal::state()->set('access_affinitygroup.allocCronSliceSize', $form_state->getValue('alloc_cron_param_slicesize'));
     \Drupal::state()->set('access_affinitygroup.allocCronImportLimit', $form_state->getValue('alloc_cron_param_importlimit'));
     \Drupal::state()->set('access_affinitygroup.allocCronNoCC', $form_state->getValue('alloc_cron_param_nocc'));

--- a/modules/access_affinitygroup/src/Plugin/AllocationsUsersImport.php
+++ b/modules/access_affinitygroup/src/Plugin/AllocationsUsersImport.php
@@ -214,7 +214,7 @@ class AllocationsUsersImport {
     $incomingCount = 0;
     $processedCount = 0;
 
-    $this->collectCronLog("Initial API import: total received: " . count($responseJson), 'i');
+    $this->collectCronLog("Initial API import: total received: " . count($responseJson), 'i', TRUE);
 
     try {
       foreach ($responseJson as $aUser) {
@@ -278,6 +278,8 @@ class AllocationsUsersImport {
       // Process each user in the chunk
       // call api to get resources, get user, (add user + add to cc if needed)
       // update user's resources if needed, check if they are members of associated ags.
+      $this->collectCronLog("Batch " . $sandbox['batchNum'] . " start", 'i', TRUE);
+
       foreach ($userNameArray as $userName) {
 
         $context['results']['totalExamined']++;
@@ -416,7 +418,7 @@ class AllocationsUsersImport {
       $this->collectCronLog("Exception while processing api results at $userCount " . $e->getMessage(), 'err');
     }
 
-    $this->collectCronLog("Batch " . $sandbox['batchNum'] . ". New users: $newUsers, CC Ids added: $newCCIds / $userCount", 'd', TRUE);
+    $this->collectCronLog("Batch " . $sandbox['batchNum'] . ". New users: $newUsers, CC Ids added: $newCCIds / $userCount", 'i', TRUE);
 
     $context['results']['logCronErrors'] = array_merge($context['results']['logCronErrors'], $this->logCronErrors);
 

--- a/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
+++ b/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
@@ -303,21 +303,30 @@ class ConstantContactApi {
     if (preg_match('/error_key/', $returned_result, $matches, PREG_OFFSET_CAPTURE)) {
 
       if (![] === $result) {
-        $this->errorMessage = $result->error_message;
-        $this->apiError($result->error_key, $result->error_message);
-        $result = NULL;
+        $errmsg = $result->error_message;
+        $errkey = $result->error_key;
       }
       else {
-        foreach ($result as $error) {
+       foreach ($result as $error) {
+        if (empty($error)) {
+          $errmsg = "Unknown ConstantContact Error.";
+          $errkey = '-';
+        }
+        elseif (is_string($error)) {
+          $errmsg = $error;
+          $errkey = '-';
+        }
+        else {
+          // Normal CC error structure.
           $errmsg = (!property_exists($error, 'error_message') || !isset($error->error_message)) ?
-            'ConstantContact Error' : $error->error_message;
+              'ConstantContact Error' : $error->error_message;
           $errkey = (!property_exists($error, 'error_key') ||  !isset($error->error_key)) ?
-            '-' : $error->error_key;
-
-          $this->errorMessage = $errmsg;
-          $this->apiError($errkey, $errmsg);
+              '-' : $error->error_key;
         }
       }
+      }
+      $this->errorMessage = $errmsg;
+      $this->apiError($errkey, $errmsg);
 
       $result = NULL;
     }

--- a/modules/user_profiles/user_profiles.module
+++ b/modules/user_profiles/user_profiles.module
@@ -4,11 +4,11 @@
  * @file
  */
 
-use GuzzleHttp\Client;
-use Drupal\user\UserInterface;
 use Drupal\Component\Serialization\Json;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\Component\Utility\Html;
+use Drupal\user\UserInterface;
+use GuzzleHttp\Client;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 $debug = FALSE;
 
@@ -99,11 +99,13 @@ function user_profiles_entity_presave(Object $entity) {
     return;
   }
 
-  if (\Drupal::state()->get('access_affinitygroup.allocationsRun')) {
+  // Need to exit if we are here during the allocations import processing,
+  // which can either be run via cron or from user 1 setting it off on the
+  // constant contact admin form.
+  $current_user = \Drupal::currentUser();
+  if ($current_user->id() === 1 || $current_user->id() === 0) {
     return;
   }
-
-  $current_user = \Drupal::currentUser();
   $account_name = $current_user->getAccountName();
   $userinfo = get_account_data_from_api($account_name);
   $is_suspended = $userinfo && array_key_exists('isSuspended', $userinfo) && $userinfo['isSuspended'];
@@ -195,21 +197,24 @@ function user_profiles_cilogon_auth_userinfo_save(UserInterface $account, array 
 
   if (array_key_exists('given_name', $userinfo)) {
     $account->set('field_user_first_name', $userinfo['given_name']);
-  } else {
+  }
+  else {
     $msg = ('given_name not found in userinfo');
     \Drupal::messenger()->addError(basename(__FILE__) . ':' . __LINE__ . ' -- ' . $msg);
   }
 
   if (array_key_exists('family_name', $userinfo)) {
     $account->set('field_user_last_name', $userinfo['family_name']);
-  } else {
+  }
+  else {
     $msg = ('family_name not found in userinfo');
     \Drupal::messenger()->addError(basename(__FILE__) . ':' . __LINE__ . ' -- ' . $msg);
   }
 
   if (array_key_exists('email', $userinfo)) {
     $account->setEmail($userinfo['email']);
-  } else {
+  }
+  else {
     $msg = ('email not found in userinfo');
     \Drupal::messenger()->addError(basename(__FILE__) . ':' . __LINE__ . ' -- ' . $msg);
   }
@@ -219,14 +224,16 @@ function user_profiles_cilogon_auth_userinfo_save(UserInterface $account, array 
   if (!array_key_exists('sub', $userinfo)) {
     $msg = ('sub not found in userinfo');
     \Drupal::messenger()->addError(basename(__FILE__) . ':' . __LINE__ . ' -- ' . $msg);
-  } else {
+  }
+  else {
     $sub = $userinfo['sub'];
 
     // But only use the handle (text before the @, if there is an @ in the sub)
     $at_position = strpos($sub, '@');
     if ($at_position > 0) {
       $user_handle = explode("@", $sub)[0];
-    } else {
+    }
+    else {
       $user_handle = $sub;
     }
 
@@ -264,7 +271,8 @@ function user_profiles_cilogon_auth_userinfo_save(UserInterface $account, array 
     if (!empty($sub)) {
       $msg = ('and set username to  = [' . $sub . ']');
       \Drupal::messenger()->addStatus(basename(__FILE__) . ':' . __LINE__ . ' -- ' . $msg);
-    } else {
+    }
+    else {
       $msg = ('did not set username because found no sub');
       \Drupal::messenger()->addStatus(basename(__FILE__) . ':' . __LINE__ . ' -- ' . $msg);
     }
@@ -313,7 +321,8 @@ function get_account_data_from_api($username) {
     $response = $client->request('GET', $request_url, $request_options);
     $userinfo = Json::decode((string) $response->getBody());
     return $userinfo;
-  } catch (Exception $e) {
+  }
+  catch (Exception $e) {
     // Display an addtional error message if response code is anything besides 404 (not found)
     if ($e->getCode() != 404) {
       $msg = "Could not retrieve user profile information: " . $e->getMessage();


### PR DESCRIPTION
## Describe context / purpose for this PR
In access-affinitygroup module, cron hook runs allocations import slices.
Decide when to run based on time and also whether all of the imports have been processed through the slices.
More + fixed logging. 
In user profile presave hook, instead of checking an unreliable state variable for allocations, 
check if user is 1 or 0 to decide if we will ignore the following code that operates  on a current user.

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-1938

## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/1030

## Link to MultiDev instance
http://md-d8-1938b-accessmatch.pantheonsite.io

## Checklist for PR author
- [x ] I have checked that the PR is ready to be merged
- [ x] I have reviewed the DIFF and checked that the changes are as expected
- [ x] I have assigned myself or someone else to review the PR
