### PR TITLE
access_misc: removes references to role cc_rollout d8-1943

### DIFF
--- a/modules/access_misc/access_misc.install
+++ b/modules/access_misc/access_misc.install
@@ -1471,3 +1471,12 @@ function access_misc_update_10014(&$sandbox) {
 EOT;
   update_node_body($nid, $body, $format);
 }
+
+/**
+ * Clear out cc_rollout roles.
+ */
+function access_misc_update_10015() {
+  $query = \Drupal::database()->delete('user__roles');
+  $query->condition('roles_target_id', 'cc_rollout');
+  $query->execute();
+}


### PR DESCRIPTION
## Describe context / purpose for this PR
Clear out old role from db.
## Issue link
https://cyberteamportal.atlassian.net/jira/software/c/projects/D8/issues/D8-1943
## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/1035
## Link to MultiDev instance
http://md-1943-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
