### PR TITLE
access_misc: update to set all access nodes to all_affiliates d8-2015

### DIFF
--- a/modules/access_misc/access_misc.install
+++ b/modules/access_misc/access_misc.install
@@ -1480,3 +1480,23 @@ function access_misc_update_10015() {
   $query->condition('roles_target_id', 'cc_rollout');
   $query->execute();
 }
+
+/**
+ * Update nodes set to Access to be 'sent to all affiliates' (D8-2015).
+ */
+function access_misc_update_10016() {
+  $connection = \Drupal::database();
+  $query = $connection->select('node__field_domain_access', 'nfa');
+  $query->fields('nfa', ['entity_id']);
+  $query->condition('nfa.field_domain_access_target_id', 'amp_cyberinfrastructure_org');
+  $result = $query->execute()->fetchCol();
+  foreach ($result as $row) {
+    $connection->delete('node__field_domain_access')
+      ->condition('entity_id', $row)
+      ->execute();
+    $connection->update('node__field_domain_all_affiliates')
+      ->fields(['field_domain_all_affiliates_value' => 1])
+      ->condition('entity_id', $row)
+      ->execute();
+  }
+}


### PR DESCRIPTION
## Describe context / purpose for this PR
ACCESS Orgs should be "Sent to all affialiates"
## Issue link
https://cyberteamportal.atlassian.net/jira/software/c/projects/D8/issues/D8-2015
## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/1110
## Link to MultiDev instance
http://md-2015-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
