### PR TITLE
For Join CSSN on Community Persona, link directly

### DIFF
--- a/modules/cssn/src/Plugin/Block/PersonaBlock.php
+++ b/modules/cssn/src/Plugin/Block/PersonaBlock.php
@@ -149,7 +149,7 @@ class PersonaBlock extends BlockBase {
         $cssn = "Not a CSSN Member";
       }
       else {
-        $cssn_url = Url::fromUri('internal:/community/cssn#join-cssn');
+        $cssn_url = Url::fromUri('https://support.access-ci.org/community/cssn#join-cssn');
         $cssn_link = Link::fromTextAndUrl('Join the CSSN', $cssn_url);
         $cssn_renderable = $cssn_link->toRenderable();
         $cssn = $cssn_renderable;


### PR DESCRIPTION
For Join CSSN on Community Persona, link directly to support.access-ci.org instead of current domain

## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2026

## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/1127

## Link to MultiDev instance

http://md-2026-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
