### PR TITLE
cssn: redirect from to users profile if same on public d8-2073

### DIFF
--- a/modules/cssn/src/Controller/CommunityPersonaController.php
+++ b/modules/cssn/src/Controller/CommunityPersonaController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Url;
 use Drupal\cssn\Plugin\Util\EndUrl;
 use Drupal\cssn\Plugin\Util\MatchLookup;
 use Drupal\cssn\Plugin\Util\ProjectLookup;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\user\Entity\User;
 use Drupal\webform\Entity\WebformSubmission;
@@ -431,6 +432,14 @@ class CommunityPersonaController extends ControllerBase {
     $end_url = new EndUrl();
     $user_id = $end_url->getUrlEnd();
     $should_user_load = FALSE;
+    // Get current user id.
+    $current_user = \Drupal::currentUser();
+    // Redirect to to profile if public persona page is for current user.
+    if ($current_user->id() == $user_id) {
+      $url = Url::fromUri('internal:/community-persona');
+      $response = new RedirectResponse($url->toString());
+      $response->send();
+    }
     if (is_numeric($user_id)) {
       $user = User::load($user_id);
       // Don't show profile for people who haven't joined a region/program.


### PR DESCRIPTION
## Describe context / purpose for this PR
Redirect community persona to user persona page if they are the same user.
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2073
## Any other related PRs?
- https://github.com/necyberteam/cyberteam_drupal/pull/1151
## Link to MultiDev instance
http://md-2073-accessmatch.pantheonsite.io

## Checklist for PR author
- [x] I have checked that the PR is ready to be merged
- [x] I have reviewed the DIFF and checked that the changes are as expected
- [x] I have assigned myself or someone else to review the PR
