### PR TITLE
deny access to create node on non-ccmnet domains d8-2191

### DIFF
--- a/modules/ccmnet/ccmnet.module
+++ b/modules/ccmnet/ccmnet.module
@@ -230,6 +230,15 @@ function ccmnet_form_alter(&$form, FormStateInterface $form_state, $form_id) {
     $form['#attached']['library'][] = 'ccmnet/mentorship_engagement';
 
     $form['#validate'][] = 'access_mentorship_engagement_validate';
+
+    // Only create mentorships on ccmnet domain.
+    $domain = \Drupal::config('domain.settings');
+    $token = \Drupal::token();
+    $domainName = Html::getClass($token->replace(t('[domain:name]')));
+    if ($domainName != 'ccmnet') {
+      \Drupal::messenger()->addWarning(t('You must be on the CCMNet domain to create a mentorship engagement.'));
+      $form['#access'] = FALSE;
+    }
   } else if ($form_id == 'user_register_form' || $form_id == 'user_form') {
     // For forms on ccmnet domain only:
     // Hide region field for both user registration and user edit.


### PR DESCRIPTION
## Describe context / purpose for this PR
Deny access to non CCMNet domains from creating mentorships.
## Issue link
https://cyberteamportal.atlassian.net/jira/software/c/projects/D8/issues/D8-2191
## Any other related PRs?
https://github.com/necyberteam/cyberteam_drupal/pull/1232
## Link to MultiDev instance
http://md-2191-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
