### PR TITLE
access_events: fix block cache d8-2417

### DIFF
--- a/modules/access_events/src/Plugin/Block/EventInstanceSidebar.php
+++ b/modules/access_events/src/Plugin/Block/EventInstanceSidebar.php
@@ -253,10 +253,10 @@ class EventInstanceSidebar extends BlockBase {
   }
 
   /**
-   *
+   * {@inheritdoc}
    */
   public function getCacheContexts() {
-    return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
+    return Cache::mergeContexts(parent::getCacheContexts(), ['route', 'user']);
   }
 
 }


### PR DESCRIPTION
## Describe context / purpose for this PR
Events registration block caching
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2417
## Any other related PRs?
- https://github.com/necyberteam/cyberteam_drupal/pull/1441
## Link to MultiDev instance
http://md-2417-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
