### PR TITLE
affinitygroup: switch to state from config for refresh_token

### DIFF
--- a/modules/access_affinitygroup/access_affinitygroup.install
+++ b/modules/access_affinitygroup/access_affinitygroup.install
@@ -12,8 +12,8 @@ function access_affinitygroup_update_10000() {
   $config = \Drupal::config('access_affinitygroup.settings');
   $refresh_token = $config->get('refresh_token');
   if (!empty($refresh_token)) {
-    \Drupal::state()->set('refresh_token', $refresh_token);
+    \Drupal::state()->set('access_affinitygroup.refresh_token', $refresh_token);
   } else {
-    \Drupal::state()->set('refresh_token', null);
+    \Drupal::state()->set('access_affinitygroup.refresh_token', null);
   }
 }

--- a/modules/access_affinitygroup/access_affinitygroup.install
+++ b/modules/access_affinitygroup/access_affinitygroup.install
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ * Set initial refresh_token state.
+ */
+function access_affinitygroup_update_10000() {
+  \Drupal::state()->set('refresh_token', 123);
+}

--- a/modules/access_affinitygroup/access_affinitygroup.install
+++ b/modules/access_affinitygroup/access_affinitygroup.install
@@ -8,5 +8,11 @@
  * Set initial refresh_token state.
  */
 function access_affinitygroup_update_10000() {
-  \Drupal::state()->set('refresh_token', 123);
+  $config = \Drupal::config('access_affinitygroup.settings');
+  $refresh_token = $config->get('refresh_token');
+  if (!empty($refresh_token)) {
+    \Drupal::state()->set('refresh_token', $refresh_token);
+  } else {
+    \Drupal::state()->set('refresh_token', null);
+  }
 }

--- a/modules/access_affinitygroup/access_affinitygroup.install
+++ b/modules/access_affinitygroup/access_affinitygroup.install
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Install and update functions for the Access Affinity Group module.
  */
 
 /**

--- a/modules/access_affinitygroup/access_affinitygroup.routing.yml
+++ b/modules/access_affinitygroup/access_affinitygroup.routing.yml
@@ -2,7 +2,7 @@ access_affinitygroup.constantcontact_form:
   path: '/admin/services/constantcontact-token'
   defaults:
     _form: '\Drupal\access_affinitygroup\Form\ConstantContact'
-    _title: 'Constant Contact setup token'
+    _title: 'Constant Contact Tools'
   requirements:
     _role: 'administrator'
 access_affinitygroup.simplelist:

--- a/modules/access_affinitygroup/src/Form/ConstantContact.php
+++ b/modules/access_affinitygroup/src/Form/ConstantContact.php
@@ -23,6 +23,7 @@ class ConstantContact extends FormBase {
     $allocCronDisable = \Drupal::state()->get('access_affinitygroup.allocCronDisable');
 
     $allocCronSliceSize = \Drupal::state()->get('access_affinitygroup.allocCronSliceSize');
+    $allocCronImportLimit = \Drupal::state()->get('access_affinitygroup.allocCronImportLimit', 0);
     // This will soon be display only:
     $allocCronStartAt = \Drupal::state()->get('access_affinitygroup.allocCronStartAt');
     $allocCronNoCC = \Drupal::state()->get('access_affinitygroup.allocCronNoCC');
@@ -129,6 +130,13 @@ class ConstantContact extends FormBase {
       '#title' => $this->t('Slice Size'),
       '#default_value' => $allocCronSliceSize,
       '#description' => $this->t("Number to process on on each cron run."),
+      '#required' => FALSE,
+    ];
+    $form['alloc_cron_param_importlimit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Import Limit'),
+      '#default_value' => $allocCronImportLimit,
+      '#description' => $this->t("Maximum number of users to import (0 = no limit)."),
       '#required' => FALSE,
     ];
     /* set this to display-only for normal operations */

--- a/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
+++ b/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
@@ -48,7 +48,7 @@ class ConstantContactApi {
       $config_factory = \Drupal::configFactory();
       $this->configSettings = $config_factory->getEditable('access_affinitygroup.settings');
       $this->accessToken = $this->configSettings->get('access_token');
-      $this->refreshToken = \Drupal::state()->get('refresh_token');
+      $this->refreshToken = \Drupal::state()->get('access_affinitygroup.refresh_token');
 
 
       $cc_key = \Drupal::service('key.repository')->getKey('constant_contact_client_id')->getKeyValue();
@@ -460,7 +460,7 @@ class ConstantContactApi {
    */
   private function setRefreshToken($refresh_token) {
     $this->refreshToken = $refresh_token;
-    \Drupal::state()->set('refresh_token', $refresh_token);
+    \Drupal::state()->set('access_affinitygroup.refresh_token', $refresh_token);
 
   }
 

--- a/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
+++ b/modules/access_affinitygroup/src/Plugin/ConstantContactApi.php
@@ -48,7 +48,8 @@ class ConstantContactApi {
       $config_factory = \Drupal::configFactory();
       $this->configSettings = $config_factory->getEditable('access_affinitygroup.settings');
       $this->accessToken = $this->configSettings->get('access_token');
-      $this->refreshToken = $this->configSettings->get('refresh_token');
+      $this->refreshToken = \Drupal::state()->get('refresh_token');
+
 
       $cc_key = \Drupal::service('key.repository')->getKey('constant_contact_client_id')->getKeyValue();
       if (empty($cc_key)) {
@@ -459,8 +460,8 @@ class ConstantContactApi {
    */
   private function setRefreshToken($refresh_token) {
     $this->refreshToken = $refresh_token;
-    $this->configSettings->set('refresh_token', $refresh_token);
-    $this->configSettings->save();
+    \Drupal::state()->set('refresh_token', $refresh_token);
+
   }
 
   /*


### PR DESCRIPTION
## Describe context / purpose for this PR
Use state for Constant Contact key
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2499
## Any other related PRs?
- https://github.com/necyberteam/cyberteam_drupal/pull/1579
## Link to MultiDev instance
http://md-2499-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR
