### PR TITLE
events/llm: try to cap generated summary to 150 characters

### DIFF
--- a/modules/access_events/access_events.module
+++ b/modules/access_events/access_events.module
@@ -529,6 +529,10 @@ function access_events_replace_summary_section_callback(array &$form, FormStateI
       $llm = \Drupal::service('access_llm.ai_references_generator');
       $llm->generateSummaryPrompt($body_filter);
       $result = $llm->summarySuggested();
+      // Truncate to 150 characters. If truncated add ellipsis.
+      if (strlen($result) > 150) {
+        $result = substr($result, 0, 147) . '...';
+      }
       $form['field_summary_replace']['field_suggest']['summary_text']['#value'] = $result;
       $form['field_summary_replace']['user_message'] = [
         '#markup' => '',

--- a/modules/access_llm/src/AiReferenceGenerator.php
+++ b/modules/access_llm/src/AiReferenceGenerator.php
@@ -306,7 +306,7 @@ class AiReferenceGenerator {
 
     $prompt = 'For the contents within brackets: ({BODY}) ';
     $prompt .= 'Return a summary of the text.';
-    $prompt .= 'It is very important that you do not exceed 15 tokens.';
+    $prompt .= 'It is very important that you do not exceed 150 characters.';
 
     $prompt = str_replace('{BODY}', $text, $prompt);
 


### PR DESCRIPTION
## Describe context / purpose for this PR
Event "Suggest Summary" produced a summary with char count over limit
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2646
## Any other related PRs?
- https://github.com/necyberteam/cyberteam_drupal/pull/1761
## Link to MultiDev instance
http://md-2646-accessmatch.pantheonsite.io

## Checklist for PR author
- [ ] I have checked that the PR is ready to be merged
- [ ] I have reviewed the DIFF and checked that the changes are as expected
- [ ] I have assigned myself or someone else to review the PR