### PR TITLE
feat: pass resourceContext to embedded qa-bot

### DIFF
--- a/js/headerfooter.js
+++ b/js/headerfooter.js
@@ -149,6 +149,7 @@ async function setMenu(menu, currentUri) {
       userEmail: email,
       userName: name,
       accessId: accessId,
+      resourceContext: embeddedTarget.dataset.resourceContext || undefined,
       loginUrl: "/login?redirect=" + currentUri,
       onAnalyticsEvent: onAnalyticsEvent,
       ...(drupalSettings.access.qaEndpoint && { qaEndpoint: drupalSettings.access.qaEndpoint }),


### PR DESCRIPTION
## Summary

One-line change: read `data-resource-context` from the `.embedded-qa-bot` div and pass it as `resourceContext` to `qaBot()`.

When the attribute is present (already populated by the RP preprocess hook), the bot fetches resource-scoped capabilities and sends scoped RAG queries.

When absent, `undefined` is passed and behavior is unchanged.

## Companion PRs

- necyberteam/access-agent#13 — agent infrastructure
- necyberteam/qa-bot-core#13 — core prop support
- necyberteam/access-qa-bot#8 — wrapper passthrough
- access-ci-org/access-ci-ui#76 — UI component passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)